### PR TITLE
React Query 적용, 예측 데이터 회색 표기

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@tanstack/react-query": "^4.29.5",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/Carousel/Carousel.tsx
+++ b/src/components/Carousel/Carousel.tsx
@@ -1,13 +1,13 @@
-import { Swiper, SwiperSlide } from 'swiper/react';
-import SwiperCore, { Navigation, Pagination } from 'swiper';
-import prev from '../../assets/svg/prev.svg';
-import next from '../../assets/svg/next.svg';
-import 'swiper/swiper.min.css';
-import * as S from './Carousel.style';
-import { buildingInfoType } from '../../type/Types';
-
+import { Swiper, SwiperSlide } from "swiper/react";
+import SwiperCore, { Navigation, Pagination } from "swiper";
+import prev from "../../assets/svg/prev.svg";
+import next from "../../assets/svg/next.svg";
+import "swiper/swiper.min.css";
+import * as S from "./Carousel.style";
+import { buildingInfoType } from "../../type/Types";
+import { buildingSrc } from "../../store/store";
 const style = {
-  width: '25rem',
+  width: "25rem",
 };
 
 const Carousel = ({
@@ -27,21 +27,19 @@ const Carousel = ({
         slidesPerView={1}
         scrollbar={{ draggable: true }}
         navigation={{
-          prevEl: '.swiper-button-prev',
-          nextEl: '.swiper-button-next',
+          prevEl: ".swiper-button-prev",
+          nextEl: ".swiper-button-next",
         }}
         pagination={{ clickable: true }}
         onSlideChange={(e) =>
-          setSelectedBuilding(buildingList[e.activeIndex].buildingName)
+          setSelectedBuilding(buildingList[e.activeIndex].name)
         }
       >
         {buildingList?.map((item: buildingInfoType, idx: number) => {
           return (
             <SwiperSlide key={idx}>
-              <S.CarouselBuildingName>
-                {item.buildingName}
-              </S.CarouselBuildingName>
-              <S.CarouselItem src={item.src}></S.CarouselItem>
+              <S.CarouselBuildingName>{item.name}</S.CarouselBuildingName>
+              <S.CarouselItem src={buildingSrc[item.id - 1]}></S.CarouselItem>
             </SwiperSlide>
           );
         })}

--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -20,16 +20,15 @@ const Dropdown = ({ dropDownInfo }: { dropDownInfo: dropDonwInfoType }) => {
         xCoordinate={dropDownInfo.xCoordinate}
         yCoordinate={dropDownInfo.yCoordinate}
       >
-        {dropDownInfo.category.map((item: string) => {
+        {dropDownInfo.category.map((item: string, idx: number) => {
           return (
-            <>
-              <S.DropdownItem
-                size={sizeObj[dropDownInfo.size]}
-                onClick={clickCategory}
-              >
-                {item}
-              </S.DropdownItem>
-            </>
+            <S.DropdownItem
+              size={sizeObj[dropDownInfo.size]}
+              onClick={clickCategory}
+              key={idx}
+            >
+              {item}
+            </S.DropdownItem>
           );
         })}
       </S.DropdownFrame>

--- a/src/hooks/useGetBuildings.ts
+++ b/src/hooks/useGetBuildings.ts
@@ -1,0 +1,5 @@
+import { useState } from 'react';
+import api from '../api/api';
+import { useQuery } from '@tanstack/react-query';
+
+const useGetFeed = () => {};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,23 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import Router from './routes/Router';
-import reportWebVitals from './reportWebVitals';
-import GlobalStyle from './GlobalStyle.style';
-import './assets/fonts/font.css';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import Router from "./routes/Router";
+import reportWebVitals from "./reportWebVitals";
+import GlobalStyle from "./GlobalStyle.style";
+import "./assets/fonts/font.css";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById("root") as HTMLElement
 );
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 root.render(
   <React.StrictMode>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,14 +5,20 @@ import Router from './routes/Router';
 import reportWebVitals from './reportWebVitals';
 import GlobalStyle from './GlobalStyle.style';
 import './assets/fonts/font.css';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement
 );
+
+const queryClient = new QueryClient();
+
 root.render(
   <React.StrictMode>
     <GlobalStyle />
-    <Router></Router>
+    <QueryClientProvider client={queryClient}>
+      <Router></Router>
+    </QueryClientProvider>
   </React.StrictMode>
 );
 

--- a/src/pages/BuildingElectricity/BuildingElectricity.tsx
+++ b/src/pages/BuildingElectricity/BuildingElectricity.tsx
@@ -1,18 +1,18 @@
-import React, { useEffect, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { Wrapper, WrapperInner } from "../../components/Wrapper/Wrapper.style";
-import Header from "../../components/Header/Header";
-import NavigationBar from "../../components/NavigationBar/NavigationBar";
-import * as S from "./BuildingElectricity.style";
-import { Chart as ChartJS, Tooltip, Legend } from "chart.js/auto";
-import { Line } from "react-chartjs-2";
-import Carousel from "../../components/Carousel/Carousel";
-import downArrow from "../../assets/svg/downArrow.svg";
-import { Dropdown } from "../../components/Dropdown/Dropdown";
-import { dropdownInfoCreater, createChartCategoryArray } from "./util";
-import { chartInfoType, chartInfoUsageType } from "../../type/Types";
-import test from "../../api/test";
-import api from "../../api/api";
+import React, { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Wrapper, WrapperInner } from '../../components/Wrapper/Wrapper.style';
+import Header from '../../components/Header/Header';
+import NavigationBar from '../../components/NavigationBar/NavigationBar';
+import * as S from './BuildingElectricity.style';
+import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
+import { Line } from 'react-chartjs-2';
+import Carousel from '../../components/Carousel/Carousel';
+import downArrow from '../../assets/svg/downArrow.svg';
+import { Dropdown } from '../../components/Dropdown/Dropdown';
+import { dropdownInfoCreater, createChartCategoryArray } from './util';
+import { chartInfoType, chartInfoUsageType } from '../../type/Types';
+import test from '../../api/test';
+import api from '../../api/api';
 import {
   monthlyInitData,
   buildingCode,
@@ -20,7 +20,7 @@ import {
   options,
   monthCategory,
   yearCategory,
-} from "../../store/store";
+} from '../../store/store';
 
 ChartJS.register(Tooltip, Legend);
 
@@ -33,28 +33,26 @@ const Chart = ({ chartState }: { chartState: any }) => {
 };
 
 const BuildingElectricity = () => {
-  const [selectedBuilding, setSelectedBuilding] = useState<string>("본관");
+  const [selectedBuilding, setSelectedBuilding] = useState<string>('본관');
   const [chartData, setChartData] = useState<chartInfoType[]>([]);
   const [chartState, setChartState] = useState(monthlyInitData);
   const [chartCategory, setChartCategory] =
-    useState<string>("월별 전기 사용량");
-  const [rightCategory, setRightCategory] = useState<string>("2023");
+    useState<string>('월별 전기 사용량');
+  const [rightCategory, setRightCategory] = useState<string>('2023');
   const [rightDropdown, setRightDropDown] = useState(yearCategory);
   const [isLeftDropdownOn, setIsLeftDropDownOn] = useState<Boolean>(false);
   const [isRightDropdownOn, setIsRightDropDownOn] = useState<Boolean>(false);
-  const { data: userInfo } = useQuery(["getProfile"], () =>
-    api("/api/buildings")
+  const { data: userInfo } = useQuery(['getProfile'], () =>
+    api('/api/buildings')
   );
-
-  useEffect(() => {
-    console.log(userInfo?.data.result);
-  }, [userInfo]);
 
   /**
    * API 호출이 들어가야 할 부분
    * @param selectedBuilding
    */
   const testAPI = async (selectedBuilding: number) => {
+    setRightCategory('2023');
+    setChartCategory('월별 전기 사용량');
     const rData = await test(selectedBuilding);
     setChartData(rData?.result);
     // 깊은 복사를 하지 않으면 chartJS서 변동 감지를 못함 JSON.parse, JSON.stringify로 깊은 복사
@@ -67,13 +65,15 @@ const BuildingElectricity = () => {
     chartStateCopy.datasets[0].backgroundColor = rData.result[
       rData.result.length - 1
     ].usages.map((data: any) => {
-      if (!data.prediction) return "rgb(75, 192, 192)";
-      else return "rgb(0,0,0,0.1)";
+      if (!data.prediction) return 'rgb(75, 192, 192)';
+      else return 'rgb(0,0,0,0.1)';
     });
 
     const years = rData.result.map((val: any) => {
       return val.year;
     });
+
+    chartStateCopy.labels = monthCategory;
 
     setRightDropDown(years);
     setChartState(chartStateCopy);
@@ -98,9 +98,13 @@ const BuildingElectricity = () => {
     );
 
     const chartStateCopy = JSON.parse(JSON.stringify(chartState));
-    chartStateCopy.datasets[0].backgroundColor = ["rgb(75, 192, 192)"];
+    chartStateCopy.datasets[0].backgroundColor = ['rgb(75, 192, 192)'];
     setRightCategory(matchChartCategory[chartCategory][0]);
     setRightDropDown(matchChartCategory[chartCategory][1]);
+
+    if (chartCategory === '연별 전기 사용량')
+      chartStateCopy.datasets[0].backgroundColor =
+        matchChartCategory[chartCategory][4];
 
     chartStateCopy.labels = matchChartCategory[chartCategory][2];
     chartStateCopy.datasets[0].data = matchChartCategory[chartCategory][3];
@@ -108,7 +112,7 @@ const BuildingElectricity = () => {
   };
 
   const setChartByDropdown = () => {
-    if (chartCategory === "월별 전기 사용량") {
+    if (chartCategory === '월별 전기 사용량') {
       const chartStateCopy = JSON.parse(JSON.stringify(chartState));
 
       // 오른쪽 카테고리를 통해 타겟을 탐색
@@ -121,26 +125,32 @@ const BuildingElectricity = () => {
 
       // 타겟이 예측인지 아닌지 뽑아내서 색깔 변경주기
       chartStateCopy.datasets[0].backgroundColor = target?.map((data: any) => {
-        if (!data.prediction) return "rgb(75, 192, 192)";
-        return "rgb(0,0,0,0.1)";
+        if (!data.prediction) return 'rgb(75, 192, 192)';
+        return 'rgb(0,0,0,0.1)';
       });
 
       setChartState(chartStateCopy);
-    } else if (chartCategory === "동월 전기 사용량") {
+    } else if (chartCategory === '동월 전기 사용량') {
       const chartStateCopy = JSON.parse(JSON.stringify(chartState));
       const curMonth = parseInt(rightCategory) - 1;
       const target = chartData.map((item: any) => item.usages[curMonth]);
+      const backgroundColor = chartData.map((item: chartInfoType) => {
+        if (!item.usages[parseInt(rightCategory) - 1].prediction)
+          return 'rgb(75, 192, 192)';
+        return 'rgb(0,0,0,0.1)';
+      });
       chartStateCopy.datasets[0].data = target?.map(
         (item: chartInfoUsageType) => item.data
       );
+      chartStateCopy.datasets[0].backgroundColor = backgroundColor;
       setChartState(chartStateCopy);
     }
   };
 
   useEffect(() => {
     testAPI(buildingCode[selectedBuilding]);
-    if (chartCategory === "월별 전기 사용량") setRightCategory("2023");
-    else if (chartCategory === "동월 전기 사용량") setRightCategory("12월");
+    if (chartCategory === '월별 전기 사용량') setRightCategory('2023');
+    else if (chartCategory === '동월 전기 사용량') setRightCategory('12월');
   }, [selectedBuilding]);
   useEffect(setChartByCategory, [chartCategory]);
   useEffect(setChartByDropdown, [rightCategory]);
@@ -166,7 +176,7 @@ const BuildingElectricity = () => {
                 {chartCategory} &nbsp;<img src={downArrow}></img>
               </S.ChartCategoryBox>
               <S.ChartYearBox onClick={rightDropdownHandler}>
-                {rightCategory}&nbsp;{" "}
+                {rightCategory}&nbsp;{' '}
                 {rightCategory && <img src={downArrow}></img>}
               </S.ChartYearBox>
             </S.ChartTopFrame>
@@ -177,10 +187,10 @@ const BuildingElectricity = () => {
           {isLeftDropdownOn && (
             <Dropdown
               dropDownInfo={dropdownInfoCreater(
-                "9.6rem",
-                "3rem",
-                "26.2rem",
-                "large",
+                '9.6rem',
+                '3rem',
+                '26.2rem',
+                'large',
                 electricityChartCategory,
                 setChartCategory,
                 setIsLeftDropDownOn
@@ -191,10 +201,10 @@ const BuildingElectricity = () => {
           {isRightDropdownOn && (
             <Dropdown
               dropDownInfo={dropdownInfoCreater(
-                "9.6rem",
-                "29.5rem",
-                "26.2rem",
-                "middle",
+                '9.6rem',
+                '29.5rem',
+                '26.2rem',
+                'middle',
                 rightDropdown,
                 setRightCategory,
                 setIsRightDropDownOn

--- a/src/pages/BuildingElectricity/BuildingElectricity.tsx
+++ b/src/pages/BuildingElectricity/BuildingElectricity.tsx
@@ -60,7 +60,6 @@ const BuildingElectricity = () => {
   const testAPI = async (selectedBuilding: number) => {
     const rData = await test(selectedBuilding);
     setChartData(rData?.result);
-    console.log(rData.result);
     // 깊은 복사를 하지 않으면 chartJS서 변동 감지를 못함 JSON.parse, JSON.stringify로 깊은 복사
     const chartStateCopy = JSON.parse(JSON.stringify(chartState));
     chartStateCopy.datasets[0].data = rData.result[0].usages.map(

--- a/src/pages/BuildingElectricity/BuildingElectricity.tsx
+++ b/src/pages/BuildingElectricity/BuildingElectricity.tsx
@@ -1,27 +1,26 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { Wrapper, WrapperInner } from '../../components/Wrapper/Wrapper.style';
-import Header from '../../components/Header/Header';
-import NavigationBar from '../../components/NavigationBar/NavigationBar';
-import * as S from './BuildingElectricity.style';
-import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
-import { Line } from 'react-chartjs-2';
-import Carousel from '../../components/Carousel/Carousel';
-import downArrow from '../../assets/svg/downArrow.svg';
-import { Dropdown } from '../../components/Dropdown/Dropdown';
-import { dropdownInfoCreater, createChartCategoryArray } from './util';
-import { chartInfoType, chartInfoUsageType } from '../../type/Types';
-import test from '../../api/test';
-import api from '../../api/api';
+import React, { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Wrapper, WrapperInner } from "../../components/Wrapper/Wrapper.style";
+import Header from "../../components/Header/Header";
+import NavigationBar from "../../components/NavigationBar/NavigationBar";
+import * as S from "./BuildingElectricity.style";
+import { Chart as ChartJS, Tooltip, Legend } from "chart.js/auto";
+import { Line } from "react-chartjs-2";
+import Carousel from "../../components/Carousel/Carousel";
+import downArrow from "../../assets/svg/downArrow.svg";
+import { Dropdown } from "../../components/Dropdown/Dropdown";
+import { dropdownInfoCreater, createChartCategoryArray } from "./util";
+import { chartInfoType, chartInfoUsageType } from "../../type/Types";
+import test from "../../api/test";
+import api from "../../api/api";
 import {
   monthlyInitData,
-  buildingList,
   buildingCode,
   electricityChartCategory,
   options,
   monthCategory,
   yearCategory,
-} from '../../store/store';
+} from "../../store/store";
 
 ChartJS.register(Tooltip, Legend);
 
@@ -34,23 +33,21 @@ const Chart = ({ chartState }: { chartState: any }) => {
 };
 
 const BuildingElectricity = () => {
-  const [selectedBuilding, setSelectedBuilding] = useState<string>(
-    buildingList[0].buildingName
-  );
+  const [selectedBuilding, setSelectedBuilding] = useState<string>("본관");
   const [chartData, setChartData] = useState<chartInfoType[]>([]);
   const [chartState, setChartState] = useState(monthlyInitData);
   const [chartCategory, setChartCategory] =
-    useState<string>('월별 전기 사용량');
-  const [rightCategory, setRightCategory] = useState<string>('2023');
+    useState<string>("월별 전기 사용량");
+  const [rightCategory, setRightCategory] = useState<string>("2023");
   const [rightDropdown, setRightDropDown] = useState(yearCategory);
   const [isLeftDropdownOn, setIsLeftDropDownOn] = useState<Boolean>(false);
   const [isRightDropdownOn, setIsRightDropDownOn] = useState<Boolean>(false);
-  const { data: userInfo } = useQuery(['getProfile'], () =>
-    api('/api/buildings')
+  const { data: userInfo } = useQuery(["getProfile"], () =>
+    api("/api/buildings")
   );
 
   useEffect(() => {
-    console.log(userInfo?.data);
+    console.log(userInfo?.data.result);
   }, [userInfo]);
 
   /**
@@ -62,17 +59,17 @@ const BuildingElectricity = () => {
     setChartData(rData?.result);
     // 깊은 복사를 하지 않으면 chartJS서 변동 감지를 못함 JSON.parse, JSON.stringify로 깊은 복사
     const chartStateCopy = JSON.parse(JSON.stringify(chartState));
-    chartStateCopy.datasets[0].data = rData.result[0].usages.map(
-      (data: any) => data.data
-    );
+    chartStateCopy.datasets[0].data = rData.result[
+      rData.result.length - 1
+    ].usages.map((data: any) => data.data);
     //   backgroundColor: ['rgb(75, 192, 192)'],
 
-    chartStateCopy.datasets[0].backgroundColor = rData.result[0].usages.map(
-      (data: any) => {
-        if (!data.prediction) return 'rgb(75, 192, 192)';
-        return 'rgb(0,0,0,0.1)';
-      }
-    );
+    chartStateCopy.datasets[0].backgroundColor = rData.result[
+      rData.result.length - 1
+    ].usages.map((data: any) => {
+      if (!data.prediction) return "rgb(75, 192, 192)";
+      else return "rgb(0,0,0,0.1)";
+    });
 
     const years = rData.result.map((val: any) => {
       return val.year;
@@ -100,10 +97,10 @@ const BuildingElectricity = () => {
       monthCategory
     );
 
+    const chartStateCopy = JSON.parse(JSON.stringify(chartState));
+    chartStateCopy.datasets[0].backgroundColor = ["rgb(75, 192, 192)"];
     setRightCategory(matchChartCategory[chartCategory][0]);
     setRightDropDown(matchChartCategory[chartCategory][1]);
-
-    const chartStateCopy = JSON.parse(JSON.stringify(chartState));
 
     chartStateCopy.labels = matchChartCategory[chartCategory][2];
     chartStateCopy.datasets[0].data = matchChartCategory[chartCategory][3];
@@ -111,7 +108,7 @@ const BuildingElectricity = () => {
   };
 
   const setChartByDropdown = () => {
-    if (chartCategory === '월별 전기 사용량') {
+    if (chartCategory === "월별 전기 사용량") {
       const chartStateCopy = JSON.parse(JSON.stringify(chartState));
 
       // 오른쪽 카테고리를 통해 타겟을 탐색
@@ -124,12 +121,12 @@ const BuildingElectricity = () => {
 
       // 타겟이 예측인지 아닌지 뽑아내서 색깔 변경주기
       chartStateCopy.datasets[0].backgroundColor = target?.map((data: any) => {
-        if (!data.prediction) return 'rgb(75, 192, 192)';
-        return 'rgb(0,0,0,0.1)';
+        if (!data.prediction) return "rgb(75, 192, 192)";
+        return "rgb(0,0,0,0.1)";
       });
 
       setChartState(chartStateCopy);
-    } else if (chartCategory === '동월 전기 사용량') {
+    } else if (chartCategory === "동월 전기 사용량") {
       const chartStateCopy = JSON.parse(JSON.stringify(chartState));
       const curMonth = parseInt(rightCategory) - 1;
       const target = chartData.map((item: any) => item.usages[curMonth]);
@@ -142,6 +139,8 @@ const BuildingElectricity = () => {
 
   useEffect(() => {
     testAPI(buildingCode[selectedBuilding]);
+    if (chartCategory === "월별 전기 사용량") setRightCategory("2023");
+    else if (chartCategory === "동월 전기 사용량") setRightCategory("12월");
   }, [selectedBuilding]);
   useEffect(setChartByCategory, [chartCategory]);
   useEffect(setChartByDropdown, [rightCategory]);
@@ -158,7 +157,7 @@ const BuildingElectricity = () => {
         <WrapperInner>
           <S.BuildingTitle>건물별 전기에너지를 확인해보세요!</S.BuildingTitle>
           <Carousel
-            buildingList={buildingList}
+            buildingList={userInfo?.data.result}
             setSelectedBuilding={setSelectedBuilding}
           ></Carousel>
           <S.ChartChangeFrame>
@@ -167,7 +166,7 @@ const BuildingElectricity = () => {
                 {chartCategory} &nbsp;<img src={downArrow}></img>
               </S.ChartCategoryBox>
               <S.ChartYearBox onClick={rightDropdownHandler}>
-                {rightCategory}&nbsp;{' '}
+                {rightCategory}&nbsp;{" "}
                 {rightCategory && <img src={downArrow}></img>}
               </S.ChartYearBox>
             </S.ChartTopFrame>
@@ -178,10 +177,10 @@ const BuildingElectricity = () => {
           {isLeftDropdownOn && (
             <Dropdown
               dropDownInfo={dropdownInfoCreater(
-                '9.6rem',
-                '3rem',
-                '26.2rem',
-                'large',
+                "9.6rem",
+                "3rem",
+                "26.2rem",
+                "large",
                 electricityChartCategory,
                 setChartCategory,
                 setIsLeftDropDownOn
@@ -192,10 +191,10 @@ const BuildingElectricity = () => {
           {isRightDropdownOn && (
             <Dropdown
               dropDownInfo={dropdownInfoCreater(
-                '9.6rem',
-                '29.5rem',
-                '26.2rem',
-                'middle',
+                "9.6rem",
+                "29.5rem",
+                "26.2rem",
+                "middle",
                 rightDropdown,
                 setRightCategory,
                 setIsRightDropDownOn

--- a/src/pages/BuildingElectricity/BuildingElectricity.tsx
+++ b/src/pages/BuildingElectricity/BuildingElectricity.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Wrapper, WrapperInner } from '../../components/Wrapper/Wrapper.style';
 import Header from '../../components/Header/Header';
 import NavigationBar from '../../components/NavigationBar/NavigationBar';
@@ -11,6 +12,7 @@ import { Dropdown } from '../../components/Dropdown/Dropdown';
 import { dropdownInfoCreater, createChartCategoryArray } from './util';
 import { chartInfoType, chartInfoUsageType } from '../../type/Types';
 import test from '../../api/test';
+import api from '../../api/api';
 import {
   monthlyInitData,
   buildingList,
@@ -43,6 +45,13 @@ const BuildingElectricity = () => {
   const [rightDropdown, setRightDropDown] = useState(yearCategory);
   const [isLeftDropdownOn, setIsLeftDropDownOn] = useState<Boolean>(false);
   const [isRightDropdownOn, setIsRightDropDownOn] = useState<Boolean>(false);
+  const { data: userInfo } = useQuery(['getProfile'], () =>
+    api('/api/buildings')
+  );
+
+  useEffect(() => {
+    console.log(userInfo?.data);
+  }, [userInfo]);
 
   /**
    * API 호출이 들어가야 할 부분
@@ -51,6 +60,7 @@ const BuildingElectricity = () => {
   const testAPI = async (selectedBuilding: number) => {
     const rData = await test(selectedBuilding);
     setChartData(rData?.result);
+    console.log(rData.result);
     // 깊은 복사를 하지 않으면 chartJS서 변동 감지를 못함 JSON.parse, JSON.stringify로 깊은 복사
     const chartStateCopy = JSON.parse(JSON.stringify(chartState));
     chartStateCopy.datasets[0].data = rData.result[0].usages.map(

--- a/src/pages/BuildingElectricity/util.ts
+++ b/src/pages/BuildingElectricity/util.ts
@@ -32,9 +32,23 @@ const createChartCategoryArray = (
     }, 0)
   );
   const monthLabel = monthCategory;
+
+  const yearBackgroundColor = chart.map((item: chartInfoType) => {
+    for (let i = 0; i < item.usages.length; i++) {
+      if (item.usages[i].prediction) return 'rgb(0,0,0,0.1)';
+    }
+    return 'rgb(75, 192, 192)';
+  });
+
   const matchChartCategory: any = {
     '월별 전기 사용량': ['2023', yearData, monthLabel],
-    '연별 전기 사용량': [null, null, yearLabel, yearTotalWaste],
+    '연별 전기 사용량': [
+      null,
+      null,
+      yearLabel,
+      yearTotalWaste,
+      yearBackgroundColor,
+    ],
     '동월 전기 사용량': ['12월', monthCategory, yearLabel],
   };
   return matchChartCategory;

--- a/src/pages/BuildingGas/BuildingGas.tsx
+++ b/src/pages/BuildingGas/BuildingGas.tsx
@@ -1,26 +1,26 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Wrapper, WrapperInner } from '../../components/Wrapper/Wrapper.style';
-import Header from '../../components/Header/Header';
-import NavigationBar from '../../components/NavigationBar/NavigationBar';
-import * as S from './BuildingGas.style';
-import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
-import { Line } from 'react-chartjs-2';
-import Carousel from '../../components/Carousel/Carousel';
-import downArrow from '../../assets/svg/downArrow.svg';
-import { Dropdown } from '../../components/Dropdown/Dropdown';
-import { dropdownInfoCreater, createChartCategoryArray } from './util';
-import { chartInfoType, chartInfoUsageType } from '../../type/Types';
-import getBuildingGas from '../../api/getBuildingGas';
+import React, { useEffect, useRef, useState } from "react";
+import { Wrapper, WrapperInner } from "../../components/Wrapper/Wrapper.style";
+import { useQuery } from "@tanstack/react-query";
+import Header from "../../components/Header/Header";
+import NavigationBar from "../../components/NavigationBar/NavigationBar";
+import * as S from "./BuildingGas.style";
+import { Chart as ChartJS, Tooltip, Legend } from "chart.js/auto";
+import { Line } from "react-chartjs-2";
+import Carousel from "../../components/Carousel/Carousel";
+import downArrow from "../../assets/svg/downArrow.svg";
+import { Dropdown } from "../../components/Dropdown/Dropdown";
+import { dropdownInfoCreater, createChartCategoryArray } from "./util";
+import { chartInfoType, chartInfoUsageType } from "../../type/Types";
+import getBuildingGas from "../../api/getBuildingGas";
 import {
   monthlyInitData,
-  buildingList,
   buildingCode,
   gasChartCategory,
   options,
   monthCategory,
   yearCategory,
-} from '../../store/store';
-
+} from "../../store/store";
+import api from "../../api/api";
 ChartJS.register(Tooltip, Legend);
 
 const Chart = ({ chartState }: { chartState: any }) => {
@@ -32,18 +32,18 @@ const Chart = ({ chartState }: { chartState: any }) => {
 };
 
 const BuildingElectricity = () => {
-  const [selectedBuilding, setSelectedBuilding] = useState<string>(
-    buildingList[0].buildingName
-  );
+  const [selectedBuilding, setSelectedBuilding] = useState<string>("본관");
   const [chartData, setChartData] = useState<chartInfoType[]>([]);
   const [chartState, setChartState] = useState(monthlyInitData);
   const [chartCategory, setChartCategory] =
-    useState<string>('월별 가스 사용량');
-  const [rightCategory, setRightCategory] = useState<string>('2023');
+    useState<string>("월별 가스 사용량");
+  const [rightCategory, setRightCategory] = useState<string>("2023");
   const [rightDropdown, setRightDropDown] = useState(yearCategory);
   const [isLeftDropdownOn, setIsLeftDropDownOn] = useState<Boolean>(false);
   const [isRightDropdownOn, setIsRightDropDownOn] = useState<Boolean>(false);
-
+  const { data: userInfo } = useQuery(["getProfile"], () =>
+    api("/api/buildings")
+  );
   /**
    * API 호출이 들어가야 할 부분
    * @param selectedBuilding
@@ -60,8 +60,8 @@ const BuildingElectricity = () => {
 
     chartStateCopy.datasets[0].backgroundColor = rData.result[0].usages.map(
       (data: any) => {
-        if (!data.prediction) return 'rgb(75, 192, 192)';
-        return 'rgb(0,0,0,0.1)';
+        if (!data.prediction) return "rgb(75, 192, 192)";
+        return "rgb(0,0,0,0.1)";
       }
     );
 
@@ -102,7 +102,7 @@ const BuildingElectricity = () => {
   };
 
   const setChartByDropdown = () => {
-    if (chartCategory === '월별 가스 사용량') {
+    if (chartCategory === "월별 가스 사용량") {
       const chartStateCopy = JSON.parse(JSON.stringify(chartState));
 
       // 오른쪽 카테고리를 통해 타겟을 탐색
@@ -115,12 +115,12 @@ const BuildingElectricity = () => {
 
       // 타겟이 예측인지 아닌지 뽑아내서 색깔 변경주기
       chartStateCopy.datasets[0].backgroundColor = target?.map((data: any) => {
-        if (!data.prediction) return 'rgb(75, 192, 192)';
-        return 'rgb(0,0,0,0.1)';
+        if (!data.prediction) return "rgb(75, 192, 192)";
+        return "rgb(0,0,0,0.1)";
       });
 
       setChartState(chartStateCopy);
-    } else if (chartCategory === '동월 가스 사용량') {
+    } else if (chartCategory === "동월 가스 사용량") {
       const chartStateCopy = JSON.parse(JSON.stringify(chartState));
       const curMonth = parseInt(rightCategory) - 1;
       const target = chartData.map((item: any) => item.usages[curMonth]);
@@ -149,7 +149,7 @@ const BuildingElectricity = () => {
         <WrapperInner>
           <S.BuildingTitle>건물별 가스에너지를 확인해보세요!</S.BuildingTitle>
           <Carousel
-            buildingList={buildingList}
+            buildingList={userInfo?.data.result}
             setSelectedBuilding={setSelectedBuilding}
           ></Carousel>
           <S.ChartChangeFrame>
@@ -158,7 +158,7 @@ const BuildingElectricity = () => {
                 {chartCategory} &nbsp;<img src={downArrow}></img>
               </S.ChartCategoryBox>
               <S.ChartYearBox onClick={rightDropdownHandler}>
-                {rightCategory}&nbsp;{' '}
+                {rightCategory}&nbsp;{" "}
                 {rightCategory && <img src={downArrow}></img>}
               </S.ChartYearBox>
             </S.ChartTopFrame>
@@ -169,10 +169,10 @@ const BuildingElectricity = () => {
           {isLeftDropdownOn && (
             <Dropdown
               dropDownInfo={dropdownInfoCreater(
-                '9.6rem',
-                '3rem',
-                '26.2rem',
-                'large',
+                "9.6rem",
+                "3rem",
+                "26.2rem",
+                "large",
                 gasChartCategory,
                 setChartCategory,
                 setIsLeftDropDownOn
@@ -183,10 +183,10 @@ const BuildingElectricity = () => {
           {isRightDropdownOn && (
             <Dropdown
               dropDownInfo={dropdownInfoCreater(
-                '9.6rem',
-                '29.5rem',
-                '26.2rem',
-                'middle',
+                "9.6rem",
+                "29.5rem",
+                "26.2rem",
+                "middle",
                 rightDropdown,
                 setRightCategory,
                 setIsRightDropDownOn

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,32 +1,32 @@
-import 본관 from '../assets/schoolImage/본관.jpg';
-import 주년60 from '../assets/schoolImage/60주년.jpg';
-import 하이테크 from '../assets/schoolImage/하이테크.jpg';
-import 정석 from '../assets/schoolImage/정석.jpg';
-import 호관2 from '../assets/schoolImage/2호관.jpg';
-import { buildingInfoType } from '../type/Types';
-import electricityIcon from '../assets/svg/electricityCategory.svg';
-import gasIcon from '../assets/svg/gasCategory.svg';
-import carbon from '../assets/svg/carbon.svg';
+import 본관 from "../assets/schoolImage/본관.jpg";
+import 주년60 from "../assets/schoolImage/60주년.jpg";
+import 하이테크 from "../assets/schoolImage/하이테크.jpg";
+import 정석 from "../assets/schoolImage/정석.jpg";
+import 호관2 from "../assets/schoolImage/2호관.jpg";
+import { buildingInfoType } from "../type/Types";
+import electricityIcon from "../assets/svg/electricityCategory.svg";
+import gasIcon from "../assets/svg/gasCategory.svg";
+import carbon from "../assets/svg/carbon.svg";
 
 const monthlyInitData: any = {
   labels: [
-    '1월',
-    '2월',
-    '3월',
-    '4월',
-    '5월',
-    '6월',
-    '7월',
-    '8월',
-    '9월',
-    '10월',
-    '11월',
-    '12월',
+    "1월",
+    "2월",
+    "3월",
+    "4월",
+    "5월",
+    "6월",
+    "7월",
+    "8월",
+    "9월",
+    "10월",
+    "11월",
+    "12월",
   ],
   datasets: [
     {
-      type: 'bar',
-      backgroundColor: ['rgb(75, 192, 192)'],
+      type: "bar",
+      backgroundColor: ["rgb(75, 192, 192)"],
       maxBarThickness: 35,
       borderRadius: 7,
       data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
@@ -35,24 +35,16 @@ const monthlyInitData: any = {
 };
 
 const seasonInitData: any = {
-  labels: ['봄', '여름', '가을', '겨울'],
+  labels: ["봄", "여름", "가을", "겨울"],
 
   datasets: [
     {
-      type: 'bar',
-      backgroundColor: 'rgb(75, 192, 192)',
+      type: "bar",
+      backgroundColor: "rgb(75, 192, 192)",
       data: [100, 400, 300, 200],
     },
   ],
 };
-
-const buildingList: buildingInfoType[] = [
-  { buildingName: '본관', src: 본관 },
-  { buildingName: '하이테크', src: 주년60 },
-  { buildingName: '하이테크', src: 하이테크 },
-  { buildingName: '정석', src: 정석 },
-  { buildingName: '2호관', src: 호관2 },
-];
 
 const buildingSrc = [
   본관,
@@ -69,40 +61,45 @@ const buildingSrc = [
 
 const buildingCode: any = Object.freeze({
   본관: 1,
-  '60주년': 2,
-  '2호관': 3,
-  하이테크: 4,
-  정석: 5,
+  하이테크관: 2,
+  정석학술정보관: 3,
+  "60주년기념관": 4,
+  "2,4호관": 5,
+  "5호관": 6,
+  "6,9호관": 7,
+  학생회관: 8,
+  서호관: 9,
+  로스쿨관: 10,
 });
 
 const electricityChartCategory = [
-  '월별 전기 사용량',
-  '연별 전기 사용량',
-  '동월 전기 사용량',
+  "월별 전기 사용량",
+  "연별 전기 사용량",
+  "동월 전기 사용량",
 ];
 
 const gasChartCategory = [
-  '월별 가스 사용량',
-  '연별 가스 사용량',
-  '동월 가스 사용량',
+  "월별 가스 사용량",
+  "연별 가스 사용량",
+  "동월 가스 사용량",
 ];
 
 const monthCategory = [
-  '1월',
-  '2월',
-  '3월',
-  '4월',
-  '5월',
-  '6월',
-  '7월',
-  '8월',
-  '9월',
-  '10월',
-  '11월',
-  '12월',
+  "1월",
+  "2월",
+  "3월",
+  "4월",
+  "5월",
+  "6월",
+  "7월",
+  "8월",
+  "9월",
+  "10월",
+  "11월",
+  "12월",
 ];
 
-const yearCategory = ['2023', '2022', '2021', '2020', '2019', '2018', '2017'];
+const yearCategory = ["2023", "2022", "2021", "2020", "2019", "2018", "2017"];
 
 const options: any = {
   reponsive: true,
@@ -114,8 +111,8 @@ const options: any = {
       callbacks: {
         title: (context: any) => context[0].label,
         label: (context: any) => {
-          let label = context.dataset.label + '' || '';
-          return context.parsed.y !== null ? context.parsed.y + 'kwh' : null;
+          let label = context.dataset.label + "" || "";
+          return context.parsed.y !== null ? context.parsed.y + "kwh" : null;
         },
       },
     },
@@ -133,7 +130,7 @@ const options: any = {
 
       title: {
         display: true,
-        text: '단위 : kwh',
+        text: "단위 : kwh",
       },
     },
   },
@@ -141,39 +138,38 @@ const options: any = {
 
 const indicateCategory = [
   {
-    content: '계절별 전력사용 순위',
+    content: "계절별 전력사용 순위",
     src: electricityIcon,
-    route: '/indicator/season/electricity',
+    route: "/indicator/season/electricity",
   },
   {
-    content: '계절별 가스사용 순위',
+    content: "계절별 가스사용 순위",
     src: gasIcon,
-    route: '/indicator/season/gas',
+    route: "/indicator/season/gas",
   },
   {
-    content: '면적당 전력사용 순위',
+    content: "면적당 전력사용 순위",
     src: electricityIcon,
-    route: '/indicator/area/electricity',
+    route: "/indicator/area/electricity",
   },
   {
-    content: '면적당 가스사용 순위',
+    content: "면적당 가스사용 순위",
     src: gasIcon,
-    route: '/indicator/area/gas',
+    route: "/indicator/area/gas",
   },
   {
-    content: '건물별 탄소 배출량',
+    content: "건물별 탄소 배출량",
     src: carbon,
-    route: '/indicator/carbon/buildings',
+    route: "/indicator/carbon/buildings",
   },
   {
-    content: '연도별 탄소 배출량',
+    content: "연도별 탄소 배출량",
     src: carbon,
-    route: '/indicator/carbon/all',
+    route: "/indicator/carbon/all",
   },
 ];
 
 export {
-  buildingList,
   monthlyInitData,
   buildingCode,
   electricityChartCategory,
@@ -183,4 +179,5 @@ export {
   indicateCategory,
   seasonInitData,
   gasChartCategory,
+  buildingSrc,
 };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -48,10 +48,23 @@ const seasonInitData: any = {
 
 const buildingList: buildingInfoType[] = [
   { buildingName: '본관', src: 본관 },
-  { buildingName: '60주년', src: 주년60 },
+  { buildingName: '하이테크', src: 주년60 },
   { buildingName: '하이테크', src: 하이테크 },
   { buildingName: '정석', src: 정석 },
   { buildingName: '2호관', src: 호관2 },
+];
+
+const buildingSrc = [
+  본관,
+  하이테크,
+  정석,
+  주년60,
+  하이테크,
+  하이테크,
+  하이테크,
+  하이테크,
+  하이테크,
+  하이테크,
 ];
 
 const buildingCode: any = Object.freeze({

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -23,11 +23,12 @@ const monthlyInitData: any = {
     '11월',
     '12월',
   ],
-
   datasets: [
     {
       type: 'bar',
       backgroundColor: ['rgb(75, 192, 192)'],
+      maxBarThickness: 35,
+      borderRadius: 7,
       data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
     },
   ],
@@ -90,11 +91,20 @@ const monthCategory = [
 
 const yearCategory = ['2023', '2022', '2021', '2020', '2019', '2018', '2017'];
 
-const options = {
-  reponsive: false,
+const options: any = {
+  reponsive: true,
   plugins: {
     legend: {
       display: false,
+    },
+    tooltip: {
+      callbacks: {
+        title: (context: any) => context[0].label,
+        label: (context: any) => {
+          let label = context.dataset.label + '' || '';
+          return context.parsed.y !== null ? context.parsed.y + 'kwh' : null;
+        },
+      },
     },
   },
   scales: {
@@ -106,6 +116,11 @@ const options = {
     y: {
       grid: {
         display: false,
+      },
+
+      title: {
+        display: true,
+        text: '단위 : kwh',
       },
     },
   },

--- a/src/type/Types.tsx
+++ b/src/type/Types.tsx
@@ -14,8 +14,12 @@ type homeCategoryType = {
 };
 
 type buildingInfoType = {
-  buildingName: string;
-  src: string;
+  id: number;
+  name: string;
+  elecArea: number;
+  elecDescription: number | null;
+  gasArea: number;
+  gasDescription: number | null;
 };
 
 type dropDonwInfoType = {

--- a/src/type/Types.tsx
+++ b/src/type/Types.tsx
@@ -34,7 +34,7 @@ type dropDonwInfoType = {
 
 type chartInfoType = {
   year: number;
-  usages: chartInfoType[];
+  usages: chartInfoUsageType[];
 };
 
 type chartInfoUsageType = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,6 +1990,19 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@tanstack/query-core@4.29.5":
+  version "4.29.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-4.29.5.tgz#a0273e88bf2fc102c4c893dc7c034127b67fd5d9"
+  integrity sha512-xXIiyQ/4r9KfaJ3k6kejqcaqFXXBTzN2aOJ5H1J6aTJE9hl/nbgAdfF6oiIu0CD5xowejJEJ6bBg8TO7BN4NuQ==
+
+"@tanstack/react-query@^4.29.5":
+  version "4.29.5"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-4.29.5.tgz#3890741291f9f925933243d78bd74dfc59d64208"
+  integrity sha512-F87cibC3s3eG0Q90g2O+hqntpCrudKFnR8P24qkH9uccEhXErnJxBC/AAI4cJRV2bfMO8IeGZQYf3WyYgmSg0w==
+  dependencies:
+    "@tanstack/query-core" "4.29.5"
+    use-sync-external-store "^1.2.0"
+
 "@testing-library/dom@^8.5.0":
   version "8.20.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-8.20.0.tgz#914aa862cef0f5e89b98cc48e3445c4c921010f6"
@@ -13293,6 +13306,11 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-sync-external-store@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
+  integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
# 작업 분류
- [ ]  버그 수정
- [x] 신규 기능
- [x] 리펙토링
- [ ] 기타
# 작업 개요
1. react-query 적용
2. 연별, 동월 데이터에 예측 사용량 회색 표기
# 작업 상세 내용
1. 연별 전기 사용량
![image](https://user-images.githubusercontent.com/76390004/236823239-5d7f82b1-61ae-49b9-bc6e-399eeba82ce0.png)

2. 동월 전기 사용량
![image](https://user-images.githubusercontent.com/76390004/236824650-d33a6eb9-0c17-4d8a-bdd0-d1860f07947e.png)

각 데이터 사용량에 예측 데이터가 포함되어 있으면 회색으로 표기하는 기능을 추가했습니다. 

