### PR TITLE
탄소 배출량 세 줄 요약 정보 확인 기능 추가

### DIFF
--- a/src/components/BuildingMoreInfo/BuildingMoreInfoGas.tsx
+++ b/src/components/BuildingMoreInfo/BuildingMoreInfoGas.tsx
@@ -11,7 +11,6 @@ import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import api from '../../api/api';
 import { findMostWasteIdx } from '../../pages/BuildingElectricity/util';
-
 ChartJS.register(Tooltip, Legend, ChartDataLabels);
 
 const MonthlyMoreInfo = ({

--- a/src/pages/Indicate/Carbon/All/CarbonAll.tsx
+++ b/src/pages/Indicate/Carbon/All/CarbonAll.tsx
@@ -8,13 +8,17 @@ import Header from '../../../../components/Header/Header';
 import NavigationBar from '../../../../components/NavigationBar/NavigationBar';
 import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
 import { Bar } from 'react-chartjs-2';
-import { options, monthlyInitData, season } from '../../../../store/store';
+import {
+  optionsCarbon,
+  monthlyInitData,
+  season,
+} from '../../../../store/store';
 import downArrow from '../../../../assets/svg/downArrow.svg';
 import * as S from './CarbonAll.style';
 import { Dropdown } from '../../../../components/Dropdown/Dropdown';
 import { dropdownInfoCreater } from '../../../BuildingElectricity/util';
 import { useQuery } from '@tanstack/react-query';
-import { getAverageFee, findMostWasteIdx } from '../util';
+import { getAverageFee, findMostWasteIdxArr } from '../util';
 import api from '../../../../api/api';
 import TransItem from '../../Component/TrasnItem/TransItem';
 import refreshSVG from '../../../../assets/svg/refresh.svg';
@@ -29,6 +33,7 @@ const CarbonAll = () => {
   );
 
   const [mostWasteSeasonIdx, setMostWasteSeasonIdx] = useState<number>(0);
+  const [mostWaste, setMostWaste] = useState<number>(0);
   const [chartData, setChartData] = useState(monthlyInitData);
   const [isDropdownOn, setIsDropdownOn] = useState<Boolean>(false);
   const [curYear, setCurYear] = useState<string>('2023');
@@ -48,6 +53,9 @@ const CarbonAll = () => {
       (acc: number, cur: number) => acc + cur,
       0
     );
+    const mostWasteIdx = findMostWasteIdxArr(usages);
+    setMostWasteSeasonIdx(mostWasteIdx);
+    setMostWaste(usages ? usages[mostWasteIdx] : 0);
     setTotalCarbon(totalUsage);
     setChartData(chartCopyData);
   };
@@ -95,7 +103,7 @@ const CarbonAll = () => {
               width="350"
               height="250"
               data={chartData}
-              options={options}
+              options={optionsCarbon}
             ></Bar>
             <S.BottomWrapper>
               <S.BottomTitle>
@@ -107,8 +115,18 @@ const CarbonAll = () => {
                     {curYear}년 총 탄소 배출량은{' '}
                     {totalCarbon?.toLocaleString('ko-KR')}kg입니다.
                   </li>
-                  <li>사회적 탄소 배출 비용은 123,123,223원 입니다.</li>
-                  <li>3월에 100kg로 가장 많은 양의 탄소를 배출했습니다.</li>
+                  <li>
+                    사회적 탄소 배출 비용은{' '}
+                    {Math.floor((totalCarbon * 55400) / 1000).toLocaleString(
+                      'ko-KR'
+                    )}
+                    원 입니다.
+                  </li>
+                  <li>
+                    {mostWasteSeasonIdx + 1}월에{' '}
+                    {mostWaste.toLocaleString('ko-KR')}kg로 가장 많은 양의
+                    탄소를 배출했습니다.
+                  </li>
                 </S.BottomInfoBoxInner>
               </S.BottomInfoBox>
               <S.BottomTitle>

--- a/src/pages/Indicate/Carbon/All/CarbonAll.tsx
+++ b/src/pages/Indicate/Carbon/All/CarbonAll.tsx
@@ -7,7 +7,7 @@ import {
 import Header from '../../../../components/Header/Header';
 import NavigationBar from '../../../../components/NavigationBar/NavigationBar';
 import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
-import { Line } from 'react-chartjs-2';
+import { Bar } from 'react-chartjs-2';
 import { options, monthlyInitData, season } from '../../../../store/store';
 import downArrow from '../../../../assets/svg/downArrow.svg';
 import * as S from './CarbonAll.style';
@@ -23,15 +23,44 @@ import TreeTransItem from '../../Component/TreeTransItem/TreeTransItem';
 
 ChartJS.register(Tooltip, Legend);
 
-const SeasonElectricity = () => {
+const CarbonAll = () => {
+  const { data: carbonData } = useQuery(['getCarbonData'], () =>
+    api('/api/carbon/year').then((data: any) => data?.data.result)
+  );
+
   const [mostWasteSeasonIdx, setMostWasteSeasonIdx] = useState<number>(0);
   const [chartData, setChartData] = useState(monthlyInitData);
   const [isDropdownOn, setIsDropdownOn] = useState<Boolean>(false);
   const [curYear, setCurYear] = useState<string>('2023');
   const [infoData, setInfoData] = useState({ watt: 0, fee: 0 });
+  const [totalCarbon, setTotalCarbon] = useState(0);
   const [randomIdxList, setRandomIdxList] = useState<number[]>(
     getUniqueNumberList(4, 8)
   );
+
+  const setCurYearChart = (chartInfo: any) => {
+    const chartCopyData = JSON.parse(JSON.stringify(chartData));
+    const usages = chartInfo?.filter(
+      (item: any) => item.year === parseInt(curYear)
+    )[0].usages;
+    chartCopyData.datasets[0].data = usages;
+    const totalUsage = usages?.reduce(
+      (acc: number, cur: number) => acc + cur,
+      0
+    );
+    setTotalCarbon(totalUsage);
+    setChartData(chartCopyData);
+  };
+
+  useEffect(() => {
+    if (carbonData) {
+      setCurYearChart(carbonData);
+    }
+  }, [carbonData]);
+
+  useEffect(() => {
+    setCurYearChart(carbonData);
+  }, [curYear]);
 
   return (
     <>
@@ -48,7 +77,7 @@ const SeasonElectricity = () => {
                     '26.2rem',
                     '2.3rem',
                     'middle',
-                    ['1,', '2', '3'],
+                    carbonData?.map((item: any) => item.year),
                     setCurYear,
                     setIsDropdownOn
                   )}
@@ -62,21 +91,24 @@ const SeasonElectricity = () => {
               </S.ChartTopFrame>
               <S.ChartIndicatorLine></S.ChartIndicatorLine>
             </S.ChartChangeFrame>
-            <Line
+            <Bar
               width="350"
-              height="200"
+              height="250"
               data={chartData}
               options={options}
-            ></Line>
+            ></Bar>
             <S.BottomWrapper>
               <S.BottomTitle>
                 해당년도 사용 1위는 '{season[mostWasteSeasonIdx]}' 입니다.
               </S.BottomTitle>
               <S.BottomInfoBox>
                 <S.BottomInfoBoxInner>
-                  <li>3월에 100kg로 가장 많은 양의 탄소를 배출했습니다.</li>
+                  <li>
+                    {curYear}년 총 탄소 배출량은{' '}
+                    {totalCarbon?.toLocaleString('ko-KR')}kg입니다.
+                  </li>
                   <li>사회적 탄소 배출 비용은 123,123,223원 입니다.</li>
-                  <li>탄소 흡수를 위해 몇 300그루의 나무를 심어야 합니다.</li>
+                  <li>3월에 100kg로 가장 많은 양의 탄소를 배출했습니다.</li>
                 </S.BottomInfoBoxInner>
               </S.BottomInfoBox>
               <S.BottomTitle>
@@ -88,10 +120,10 @@ const SeasonElectricity = () => {
               </S.BottomTitle>
               <TransItem
                 type={'carbon'}
-                waste={10000}
+                waste={totalCarbon}
                 randomIdxList={randomIdxList}
               ></TransItem>
-              <TreeTransItem carbonWaste={10000}></TreeTransItem>
+              <TreeTransItem carbonWaste={totalCarbon}></TreeTransItem>
             </S.BottomWrapper>
           </S.SeasonWrapper>
         </WrapperInner>
@@ -101,4 +133,4 @@ const SeasonElectricity = () => {
   );
 };
 
-export default SeasonElectricity;
+export default CarbonAll;

--- a/src/pages/Indicate/Carbon/util.ts
+++ b/src/pages/Indicate/Carbon/util.ts
@@ -15,6 +15,14 @@ const findMostWasteIdx = (chart: any) => {
   );
 };
 
+const findMostWasteIdxArr = (chart: any) => {
+  return chart?.reduce(
+    (iMax: number, x: number, idx: number, arr: number[]) =>
+      x > arr[iMax] ? idx : iMax,
+    0
+  );
+};
+
 const getRandomNumber = (max: number, min = 0) => {
   return Math.floor(Math.random() * max) + min;
 };
@@ -29,4 +37,9 @@ const getUniqueNumberList = (count: number, max: number, min = 0) => {
   return Array.from(list);
 };
 
-export { getAverageFee, findMostWasteIdx, getUniqueNumberList };
+export {
+  getAverageFee,
+  findMostWasteIdx,
+  findMostWasteIdxArr,
+  getUniqueNumberList,
+};

--- a/src/pages/Indicate/Component/TreeTransItem/TreeTransItem.tsx
+++ b/src/pages/Indicate/Component/TreeTransItem/TreeTransItem.tsx
@@ -12,7 +12,7 @@ const TreeTransItem = ({ carbonWaste }: { carbonWaste: number }) => {
     },
     {
       treeName: '잣나무',
-      value: '10그루',
+      value: `${Math.floor(carbonWaste / 180.8)}그루`,
       src: koreanPineTree,
     },
     {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -335,6 +335,44 @@ const optionsGas: any = {
   },
 };
 
+const optionsCarbon: any = {
+  reponsive: false,
+  plugins: {
+    datalabels: {
+      display: false,
+    },
+    legend: {
+      display: false,
+    },
+    tooltip: {
+      callbacks: {
+        title: (context: any) => context[0].label,
+        label: (context: any) => {
+          let label = context.dataset.label + '' || '';
+          return context.parsed.y !== null ? context.parsed.y + 'kg' : null;
+        },
+      },
+    },
+  },
+  scales: {
+    x: {
+      grid: {
+        display: false,
+      },
+    },
+    y: {
+      grid: {
+        display: false,
+      },
+
+      title: {
+        display: true,
+        text: '단위 : kg',
+      },
+    },
+  },
+};
+
 const indicateCategory = [
   {
     content: '계절별 전력사용 순위',
@@ -420,4 +458,5 @@ export {
   optionsAreaGas,
   optionsDoughnut,
   doughnutColor,
+  optionsCarbon,
 };


### PR DESCRIPTION
# 작업 분류
- [ ]  버그 수정
- [x] 신규 기능
- [ ] 리펙토링
- [ ] 기타
# 작업 개요
1. 탄소 세 줄 요약 정보 확인 기능 추가
# 작업 상세 내용
1. 탄소 세줄 요약 정보 확인 기능 추가
![image](https://github.com/2023-1-Capstone/frontend/assets/76390004/490ee46e-ed1d-4871-b407-174595a704fe)

- 해당 년도의 총 탄소 배출량 표기
- 사회적 탄소 배출 비용 표기(kg당 55,400원 기준)
- 가장 많은 탄소 배출을 한 시기 표기
