### PR TITLE
건물별 탄소 페이지 나무 변환 기능 추가

### DIFF
--- a/src/pages/Indicate/Carbon/Buildings/CarbonBuildings.tsx
+++ b/src/pages/Indicate/Carbon/Buildings/CarbonBuildings.tsx
@@ -61,7 +61,7 @@ const AreaElectricity = () => {
         <WrapperInner>
           <S.SeasonWrapper>
             <S.SeasonTitle>건물별 탄소 배출 현황을 확인해보세요!</S.SeasonTitle>
-            <S.Description>아래는 건물별 탄소 그래프에요</S.Description>
+            <S.Description>아래는 탄소 배출량 공식이에요</S.Description>
 
             <S.ChartChangeFrame>
               {isYearDropdownOn && (
@@ -117,12 +117,9 @@ const AreaElectricity = () => {
                 height="250"
               ></Bar>
             </S.Container>
-
-            <S.BottomWrapper>
-              <CarbonBuildingMoreInfo
-                chartState={chartData}
-              ></CarbonBuildingMoreInfo>
-            </S.BottomWrapper>
+            <CarbonBuildingMoreInfo
+              chartState={chartData}
+            ></CarbonBuildingMoreInfo>
           </S.SeasonWrapper>
         </WrapperInner>
         <NavigationBar navigationStatus="indicator"></NavigationBar>

--- a/src/pages/Indicate/Carbon/Buildings/Component/CarbonBuildingMoreInfo.style.tsx
+++ b/src/pages/Indicate/Carbon/Buildings/Component/CarbonBuildingMoreInfo.style.tsx
@@ -2,24 +2,11 @@ import styled from 'styled-components';
 
 const BuildingMoreInfoFrame = styled.div`
   position: relative;
-  width: 36rem;
-  height: 77rem;
-  background: #fff;
-  border-radius: 1rem;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  padding-bottom: 1rem;
-`;
-
-const BuildingMoreInfoInner = styled.div`
-  position: relative;
   flex-direction: column;
   align-items: center;
   display: flex;
-  width: 33rem;
-  height: 71.9rem;
+  width: 36rem;
+  height: 95rem;
   background: #fff;
   border-radius: 0.7rem;
 `;
@@ -34,6 +21,7 @@ const BuildingMoreInfoTitle = styled.div`
   font-weight: 700;
   font-size: 2rem;
   display: flex;
+  margin-top: 1rem;
   align-items: center;
   opacity: 0.7;
   color: #000000;
@@ -130,7 +118,6 @@ const RefreshButton = styled.img`
 export {
   BuildingMoreInfoTitle,
   BuildingMoreInfoFrame,
-  BuildingMoreInfoInner,
   Container,
   BuildingMoreInfoSummary,
   ChartIndicatorLine,

--- a/src/pages/Indicate/Carbon/Buildings/Component/CarbonBuildingMoreInfo.tsx
+++ b/src/pages/Indicate/Carbon/Buildings/Component/CarbonBuildingMoreInfo.tsx
@@ -15,8 +15,7 @@ import { plugin } from '../../../../../store/chartPlugin';
 import TransItem from '../../../Component/TrasnItem/TransItem';
 import { getUniqueNumberList } from '../../util';
 import refreshSVG from '../../../../../assets/svg/refresh.svg';
-import next from '../../../../../assets/svg/next.svg';
-import prev from '../../../../../assets/svg/prev.svg';
+import TreeTransItem from '../../../Component/TreeTransItem/TreeTransItem';
 ChartJS.register(Tooltip, Legend, ChartDataLabels);
 
 const CarbonBuildingMoreInfo = ({ chartState }: { chartState: any }) => {
@@ -65,34 +64,37 @@ const CarbonBuildingMoreInfo = ({ chartState }: { chartState: any }) => {
 
   return (
     <S.BuildingMoreInfoFrame>
-      <S.BuildingMoreInfoInner>
-        <S.BuildingMoreInfoTitle>요약 정보</S.BuildingMoreInfoTitle>
-        <S.ChartIndicatorLine></S.ChartIndicatorLine>
-        <S.Container>
-          <Doughnut
-            data={chartData}
-            options={optionsDoughnutCarbon}
-            plugins={[plugin]}
-          ></Doughnut>
-        </S.Container>
-        <S.BuildingMoreInfoSummary>
-          <li>가장 많은 탄소를 배출한 건물은 '123'입니다.</li>
-          <li>가장 적은 탄소를 배출한 건물은 '123'입니다.</li>
-          <li>건물 평균 123kg를 배출하였습니다.</li>
-        </S.BuildingMoreInfoSummary>
-        <S.BottomTitle>
-          해당 시기 탄소 배출량은...
-          <S.RefreshButton
-            src={refreshSVG}
-            onClick={() => setRandomIdxList(getUniqueNumberList(4, 8))}
-          ></S.RefreshButton>
-        </S.BottomTitle>
-        <TransItem
-          type={'carbon'}
-          randomIdxList={randomIdxList}
-          waste={moreInfo.totalCarbonWaste}
-        ></TransItem>
-      </S.BuildingMoreInfoInner>
+      <S.BuildingMoreInfoTitle>요약 정보</S.BuildingMoreInfoTitle>
+      <S.ChartIndicatorLine></S.ChartIndicatorLine>
+      <S.Container>
+        <Doughnut
+          data={chartData}
+          options={optionsDoughnutCarbon}
+          plugins={[plugin]}
+        ></Doughnut>
+      </S.Container>
+      <S.BuildingMoreInfoSummary>
+        <li>
+          가장 많은 탄소를 배출한 건물은 '{moreInfo.mostWasteBuilding}'입니다.
+        </li>
+        <li>
+          가장 적은 탄소를 배출한 건물은 '{moreInfo.lessWasteBuilding}'입니다.
+        </li>
+        <li>건물 평균 {moreInfo.averageWaste}kg를 배출하였습니다.</li>
+      </S.BuildingMoreInfoSummary>
+      <S.BottomTitle>
+        해당 시기 탄소 배출량은...
+        <S.RefreshButton
+          src={refreshSVG}
+          onClick={() => setRandomIdxList(getUniqueNumberList(4, 8))}
+        ></S.RefreshButton>
+      </S.BottomTitle>
+      <TransItem
+        type={'carbon'}
+        randomIdxList={randomIdxList}
+        waste={moreInfo.totalCarbonWaste}
+      ></TransItem>
+      <TreeTransItem carbonWaste={moreInfo.totalCarbonWaste}></TreeTransItem>
     </S.BuildingMoreInfoFrame>
   );
 };


### PR DESCRIPTION
# 작업 분류
- [ ]  버그 수정
- [x] 신규 기능
- [ ] 리펙토링
- [ ] 기타
# 작업 개요
1. 건물별 탄소 페이지 나무 변환 기능 추가

# 상세 작업 내용
1. 건물별 탄소 페이지 나무 변환 기능 추가
![image](https://github.com/2023-1-Capstone/frontend/assets/76390004/2699ef09-23b3-4e4b-913d-4bc3241df2c3)
- 건물별 탄소 페이지에서도 나무 변환을 확인할 수 있습니다.