### PR TITLE
면적별 전기, 가스 지표 디자인 수정

### DIFF
--- a/src/pages/Indicate/Area/electricity/AreaElectricity.style.tsx
+++ b/src/pages/Indicate/Area/electricity/AreaElectricity.style.tsx
@@ -14,11 +14,12 @@ const SeasonTitle = styled.div`
 
   font-family: 'Pretendard';
   font-style: normal;
-  font-weight: 700;
+  font-weight: 400;
   font-size: 2.4rem;
   line-height: 2.9rem;
-  margin-top: 3rem;
-  color: #000000;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+  color: #ffffff;
 `;
 
 const ChartChangeFrame = styled.div`
@@ -37,6 +38,7 @@ const ChartTopFrame = styled.div`
   justify-content: center;
   align-items: center;
   padding: 0px;
+  top: -1rem;
   gap: 15rem;
   left: 5px;
   position: relative;
@@ -48,26 +50,27 @@ const ChartCategoryBox = styled.div`
   position: absolute;
 
   width: fit-content;
-  height: fit-content;
+  height: 2.7rem;
 
   &:hover {
     background-color: #e7e7e7;
   }
+  border: 1px solid #e7e7e7;
 
   cursor: pointer;
 
-  left: 0.5rem;
-
+  left: -0.5rem;
+  padding: 5px;
   border-radius: 0.3rem;
 
   font-family: 'Pretendard';
   font-style: normal;
   font-weight: 700;
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   line-height: 1.7rem;
   display: flex;
   align-items: center;
-
+  opacity: 0.7;
   color: #000000;
 
   /* Inside auto layout */
@@ -80,21 +83,24 @@ const ChartCategoryBox = styled.div`
 const ChartYearBox = styled.div`
   position: absolute;
   width: fit-content;
-  height: fit-content;
+  height: 2.7rem;
+  padding: 5px;
 
   &:hover {
     background-color: #e7e7e7;
   }
 
+  border: 1px solid #e7e7e7;
+
   cursor: pointer;
 
-  left: 20rem;
+  left: 0.5rem;
 
   border-radius: 0.3rem;
   font-family: 'Pretendard';
   font-style: normal;
   font-weight: 700;
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   line-height: 2rem;
   /* or 286% */
 
@@ -102,7 +108,7 @@ const ChartYearBox = styled.div`
   align-items: center;
   text-align: center;
 
-  color: #000000;
+  color: #777777;
 
   /* Inside auto layout */
 
@@ -114,21 +120,24 @@ const ChartYearBox = styled.div`
 const ChartMonthBox = styled.div`
   position: absolute;
   width: fit-content;
-  height: fit-content;
+  height: 2.7rem;
+  padding: 5px;
 
   &:hover {
     background-color: #e7e7e7;
   }
 
+  border: 1px solid #e7e7e7;
+
   cursor: pointer;
 
-  left: 28rem;
+  left: 10rem;
 
   border-radius: 0.3rem;
   font-family: 'Pretendard';
   font-style: normal;
   font-weight: 700;
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   line-height: 2rem;
   /* or 286% */
 
@@ -136,7 +145,7 @@ const ChartMonthBox = styled.div`
   align-items: center;
   text-align: center;
 
-  color: #000000;
+  color: #777777;
 
   /* Inside auto layout */
 
@@ -279,6 +288,118 @@ const RefreshButton = styled.img`
   cursor: pointer;
 `;
 
+const Container = styled.div`
+  background-color: #ffffff;
+  top: 0rem;
+  position: relative;
+  width: 36rem;
+  height: fit-content;
+  border-radius: 0.5rem;
+  margin-bottom: 0rem;
+`;
+
+const BuildingInfoFrame = styled.div<{ modalState: string }>`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: fit-content;
+  top: 9.5rem;
+  right: 2rem;
+  height: fit-content;
+  border-radius: 0.5rem;
+  background-color: #fefbf6;
+  border: 2px solid #eee;
+  padding: 1rem;
+  z-index: 2;
+  visibility: ${(props) => props.modalState};
+`;
+
+const BuildingInfoNotice = styled.div`
+  position: relative;
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 17px;
+
+  color: #757575;
+`;
+
+const BuildingInfoItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 0.2rem;
+
+  position: relative;
+  width: 33rem;
+  height: fit-content;
+`;
+
+const BuildingInfoItemTitle = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 19px;
+
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const BuildingInfoItemContent = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 17px;
+
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const Calculate = styled.div`
+  position: relative;
+  height: fit-content;
+  width: 36rem;
+  display: flex;
+  align-items: center;
+  text-align: right;
+  font-size: 1.7rem;
+  justify-content: flex-end;
+  margin-top: -1rem;
+  color: #fff;
+  font-weight: 400;
+`;
+
+const InfoImage = styled.img`
+  width: 2rem;
+  height: 2rem;
+  background: url(${(props) => props.src});
+  cursor: pointer;
+`;
+
 export {
   SeasonWrapper,
   ChartCategoryBox,
@@ -296,4 +417,12 @@ export {
   BottomInfoTransText,
   SeasonTitle,
   RefreshButton,
+  Container,
+  BuildingInfoFrame,
+  BuildingInfoNotice,
+  BuildingInfoItem,
+  BuildingInfoItemTitle,
+  BuildingInfoItemContent,
+  Calculate,
+  InfoImage
 };

--- a/src/pages/Indicate/Area/electricity/AreaElectricity.tsx
+++ b/src/pages/Indicate/Area/electricity/AreaElectricity.tsx
@@ -22,6 +22,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getBuildingTargetDataElectricity, findMostWasteIdx } from '../util';
 import api from '../../../../api/api';
 import AreaElectricityMoreInfo from './Component/AreaElectricityMoreInfo';
+import informationSVG from "../../../../assets/svg/information.svg";
 
 ChartJS.register(Tooltip, Legend);
 
@@ -44,6 +45,7 @@ const AreaElectricity = () => {
   const [isMonthDropdownOn, setIsMonthDropdownOn] = useState<Boolean>(false);
   const [curYear, setCurYear] = useState<string>('2023');
   const [curMonth, setCurMonth] = useState<string>('1');
+  const [infoModalState, setInfoModalState] = useState<string>('hidden');
 
   const createNewChartData = (newData: number[]) => {
     const chartCopyState = JSON.parse(JSON.stringify(chartData));
@@ -87,60 +89,93 @@ const AreaElectricity = () => {
         <WrapperInner>
           <S.SeasonWrapper>
             <S.SeasonTitle>👑면적당 전기 사용 순위</S.SeasonTitle>
-            <S.ChartChangeFrame>
-              {isYearDropdownOn && (
-                <Dropdown
-                  dropDownInfo={dropdownInfoCreater(
-                    '10rem',
-                    '20.2rem',
-                    '2.3rem',
-                    'middle',
-                    areaData[0]?.usagesList.map((item: any) => item.year),
-                    setCurYear,
-                    setIsYearDropdownOn
-                  )}
-                ></Dropdown>
-              )}
-              {isMonthDropdownOn && (
-                <Dropdown
-                  dropDownInfo={dropdownInfoCreater(
-                    '10rem',
-                    '27.2rem',
-                    '2.3rem',
-                    'middle',
-                    monthCategory,
-                    setCurMonth,
-                    setIsMonthDropdownOn
-                  )}
-                ></Dropdown>
-              )}
-              <S.ChartTopFrame>
-                <S.ChartCategoryBox>면적당 사용량</S.ChartCategoryBox>
-                <S.ChartYearBox
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setIsYearDropdownOn(true);
+
+            <S.BuildingInfoFrame modalState={infoModalState}>
+              <S.BuildingInfoNotice>
+                ※ 아래는 전기 사용량에 포함된 건물들 정보에요.
+              </S.BuildingInfoNotice>
+              <S.BuildingInfoItem>
+                <S.BuildingInfoItemTitle>전기사용량⚡</S.BuildingInfoItemTitle>
+                {buildingData?.map((item: any) => {
+                  return (
+                      <>
+                        {item.elecDescription ? (
+                            <S.BuildingInfoItemContent>{`- ${item.name} : ${item.elecDescription}`}</S.BuildingInfoItemContent>
+                        ) : null}
+                      </>
+                  );
+                })}
+              </S.BuildingInfoItem>
+            </S.BuildingInfoFrame>
+            <S.Calculate>
+              건물정보
+              <S.InfoImage
+                  width="20px"
+                  height="20px"
+                  src={informationSVG}
+                  onMouseEnter={() => {
+                    setInfoModalState("visible");
                   }}
-                >
-                  {curYear}년 &nbsp;<img src={downArrow}></img>
-                </S.ChartYearBox>
-                <S.ChartMonthBox
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setIsMonthDropdownOn(true);
+                  onMouseLeave={() => {
+                    setInfoModalState("hidden");
                   }}
-                >
-                  {curMonth}월 &nbsp;<img src={downArrow}></img>
-                </S.ChartMonthBox>
-              </S.ChartTopFrame>
-              <S.ChartIndicatorLine></S.ChartIndicatorLine>
-            </S.ChartChangeFrame>
-            <Bar
-              data={chartData}
-              options={optionsArea}
-              width="270"
-              height="200"
-            ></Bar>
+              ></S.InfoImage>
+            </S.Calculate>
+
+            <S.Container>
+              <S.ChartChangeFrame>
+                {isYearDropdownOn && (
+                  <Dropdown
+                    dropDownInfo={dropdownInfoCreater(
+                      '10rem',
+                      '20.2rem',
+                      '2.3rem',
+                      'middle',
+                      areaData[0]?.usagesList.map((item: any) => item.year),
+                      setCurYear,
+                      setIsYearDropdownOn
+                    )}
+                  ></Dropdown>
+                )}
+                {isMonthDropdownOn && (
+                  <Dropdown
+                    dropDownInfo={dropdownInfoCreater(
+                      '10rem',
+                      '27.2rem',
+                      '2.3rem',
+                      'middle',
+                      monthCategory,
+                      setCurMonth,
+                      setIsMonthDropdownOn
+                    )}
+                  ></Dropdown>
+                )}
+                <S.ChartTopFrame>
+                  <S.ChartYearBox
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setIsYearDropdownOn(true);
+                    }}
+                  >
+                    {curYear}년 &nbsp;<img src={downArrow}></img>
+                  </S.ChartYearBox>
+                  <S.ChartMonthBox
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setIsMonthDropdownOn(true);
+                    }}
+                  >
+                    {curMonth}월 &nbsp;<img src={downArrow}></img>
+                  </S.ChartMonthBox>
+                </S.ChartTopFrame>
+              </S.ChartChangeFrame>
+                <Bar
+                  data={chartData}
+                  options={optionsArea}
+                  width="270"
+                  height="250"
+                ></Bar>
+            </S.Container>
             <AreaElectricityMoreInfo
               chartState={chartData}
               buildingData={buildingData}

--- a/src/pages/Indicate/Area/gas/AreaGas.style.tsx
+++ b/src/pages/Indicate/Area/gas/AreaGas.style.tsx
@@ -14,11 +14,22 @@ const SeasonTitle = styled.div`
 
   font-family: 'Pretendard';
   font-style: normal;
-  font-weight: 700;
+  font-weight: 400;
   font-size: 2.4rem;
   line-height: 2.9rem;
-  margin-top: 3rem;
-  color: #000000;
+  margin-top: 1rem;
+  margin-bottom: 2rem;
+  color: #ffffff;
+`;
+
+const Container = styled.div`
+  background-color: #ffffff;
+  top: 0rem;
+  position: relative;
+  width: 36rem;
+  height: fit-content;
+  border-radius: 0.5rem;
+  margin-bottom: 0rem;
 `;
 
 const ChartChangeFrame = styled.div`
@@ -37,6 +48,7 @@ const ChartTopFrame = styled.div`
   justify-content: center;
   align-items: center;
   padding: 0px;
+  top: -1rem;
   gap: 15rem;
   left: 5px;
   position: relative;
@@ -80,21 +92,24 @@ const ChartCategoryBox = styled.div`
 const ChartYearBox = styled.div`
   position: absolute;
   width: fit-content;
-  height: fit-content;
+  height: 2.7rem;
+  padding: 5px;
 
   &:hover {
     background-color: #e7e7e7;
   }
 
+  border: 1px solid #e7e7e7;
+
   cursor: pointer;
 
-  left: 20rem;
+  left: 0.5rem;
 
   border-radius: 0.3rem;
   font-family: 'Pretendard';
   font-style: normal;
   font-weight: 700;
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   line-height: 2rem;
   /* or 286% */
 
@@ -102,7 +117,7 @@ const ChartYearBox = styled.div`
   align-items: center;
   text-align: center;
 
-  color: #000000;
+  color: #777777;
 
   /* Inside auto layout */
 
@@ -114,21 +129,24 @@ const ChartYearBox = styled.div`
 const ChartMonthBox = styled.div`
   position: absolute;
   width: fit-content;
-  height: fit-content;
+  height: 2.7rem;
+  padding: 5px;
 
   &:hover {
     background-color: #e7e7e7;
   }
 
+  border: 1px solid #e7e7e7;
+
   cursor: pointer;
 
-  left: 28rem;
+  left: 10rem;
 
   border-radius: 0.3rem;
   font-family: 'Pretendard';
   font-style: normal;
   font-weight: 700;
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   line-height: 2rem;
   /* or 286% */
 
@@ -136,7 +154,7 @@ const ChartMonthBox = styled.div`
   align-items: center;
   text-align: center;
 
-  color: #000000;
+  color: #777777;
 
   /* Inside auto layout */
 
@@ -279,6 +297,109 @@ const RefreshButton = styled.img`
   cursor: pointer;
 `;
 
+const BuildingInfoFrame = styled.div<{ modalState: string }>`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: fit-content;
+  top: 9.5rem;
+  right: 2rem;
+  height: fit-content;
+  border-radius: 0.5rem;
+  background-color: #fefbf6;
+  border: 2px solid #eee;
+  padding: 1rem;
+  z-index: 2;
+  visibility: ${(props) => props.modalState};
+`;
+
+const BuildingInfoNotice = styled.div`
+  position: relative;
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 17px;
+
+  color: #757575;
+`;
+
+const BuildingInfoItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 0.2rem;
+
+  position: relative;
+  width: 33rem;
+  height: fit-content;
+`;
+
+const BuildingInfoItemTitle = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 19px;
+
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const BuildingInfoItemContent = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 17px;
+
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const Calculate = styled.div`
+  position: relative;
+  height: fit-content;
+  width: 36rem;
+  display: flex;
+  align-items: center;
+  text-align: right;
+  font-size: 1.7rem;
+  justify-content: flex-end;
+  margin-top: -1rem;
+  color: #fff;
+  font-weight: 400;
+`;
+
+const InfoImage = styled.img`
+  width: 2rem;
+  height: 2rem;
+  background: url(${(props) => props.src});
+  cursor: pointer;
+`;
+
+
 export {
   SeasonWrapper,
   ChartCategoryBox,
@@ -296,4 +417,12 @@ export {
   BottomInfoTransText,
   SeasonTitle,
   RefreshButton,
+  Container,
+  Calculate,
+  BuildingInfoFrame,
+  BuildingInfoItemContent,
+  BuildingInfoNotice,
+  BuildingInfoItemTitle,
+  BuildingInfoItem,
+  InfoImage
 };

--- a/src/pages/Indicate/Area/gas/AreaGas.tsx
+++ b/src/pages/Indicate/Area/gas/AreaGas.tsx
@@ -7,8 +7,8 @@ import {
 import Header from '../../../../components/Header/Header';
 import NavigationBar from '../../../../components/NavigationBar/NavigationBar';
 import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
-import { Line } from 'react-chartjs-2';
-import { optionsAreaGas, areaInitData } from '../../../../store/store';
+import { Bar } from 'react-chartjs-2';
+import {optionsAreaGas, areaInitData, optionsArea} from '../../../../store/store';
 import downArrow from '../../../../assets/svg/downArrow.svg';
 import * as S from './AreaGas.style';
 import { Dropdown } from '../../../../components/Dropdown/Dropdown';
@@ -17,6 +17,7 @@ import { dropdownInfoCreater } from '../../../BuildingElectricity/util';
 import { useQuery } from '@tanstack/react-query';
 import { getBuildingTargetDataGas, findMostWasteIdx } from '../util';
 import api from '../../../../api/api';
+import informationSVG from "../../../../assets/svg/information.svg";
 
 ChartJS.register(Tooltip, Legend);
 
@@ -42,6 +43,7 @@ const AreaElectricity = () => {
   const [curYear, setCurYear] = useState<string>('2023');
   const [curMonth, setCurMonth] = useState<string>('1');
   const [mostWasteIdx, setMostWasteIdx] = useState<number>(-1);
+  const [infoModalState, setInfoModalState] = useState<string>('hidden');
 
   const createNewChartData = (newData: number[]) => {
     const chartCopyState = JSON.parse(JSON.stringify(chartData));
@@ -99,60 +101,93 @@ const AreaElectricity = () => {
         <WrapperInner>
           <S.SeasonWrapper>
             <S.SeasonTitle>👑면적당 가스 사용 순위</S.SeasonTitle>
-            <S.ChartChangeFrame>
-              {isYearDropdownOn && (
-                <Dropdown
-                  dropDownInfo={dropdownInfoCreater(
-                    '10rem',
-                    '20.2rem',
-                    '2.3rem',
-                    'middle',
-                    areaData[0]?.usagesList.map((item: any) => item.year),
-                    setCurYear,
-                    setIsYearDropdownOn
-                  )}
-                ></Dropdown>
-              )}
-              {isMonthDropdownOn && (
-                <Dropdown
-                  dropDownInfo={dropdownInfoCreater(
-                    '10rem',
-                    '27.2rem',
-                    '2.3rem',
-                    'middle',
-                    monthCategory,
-                    setCurMonth,
-                    setIsMonthDropdownOn
-                  )}
-                ></Dropdown>
-              )}
-              <S.ChartTopFrame>
-                <S.ChartCategoryBox>면적당 사용량</S.ChartCategoryBox>
-                <S.ChartYearBox
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setIsYearDropdownOn(true);
+
+            <S.BuildingInfoFrame modalState={infoModalState}>
+              <S.BuildingInfoNotice>
+                ※ 아래는 가스 사용량에 포함된 건물들 정보에요.
+              </S.BuildingInfoNotice>
+              <S.BuildingInfoItem>
+                <S.BuildingInfoItemTitle>가스사용량⛽</S.BuildingInfoItemTitle>
+                {buildingData?.map((item: any) => {
+                  return (
+                      <>
+                        {item.gasDescription ? (
+                            <S.BuildingInfoItemContent>{`- ${item.name} : ${item.gasDescription}`}</S.BuildingInfoItemContent>
+                        ) : null}
+                      </>
+                  );
+                })}
+              </S.BuildingInfoItem>
+            </S.BuildingInfoFrame>
+            <S.Calculate>
+              건물정보
+              <S.InfoImage
+                  width="20px"
+                  height="20px"
+                  src={informationSVG}
+                  onMouseEnter={() => {
+                    setInfoModalState("visible");
                   }}
-                >
-                  {curYear}년 &nbsp;<img src={downArrow}></img>
-                </S.ChartYearBox>
-                <S.ChartMonthBox
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setIsMonthDropdownOn(true);
+                  onMouseLeave={() => {
+                    setInfoModalState("hidden");
                   }}
-                >
-                  {curMonth}월 &nbsp;<img src={downArrow}></img>
-                </S.ChartMonthBox>
-              </S.ChartTopFrame>
-              <S.ChartIndicatorLine></S.ChartIndicatorLine>
-            </S.ChartChangeFrame>
-            <Line
-              data={chartData}
-              options={optionsAreaGas}
-              width="270"
-              height="200"
-            ></Line>
+              ></S.InfoImage>
+            </S.Calculate>
+
+              <S.Container>
+                <S.ChartChangeFrame>
+                  {isYearDropdownOn && (
+                    <Dropdown
+                      dropDownInfo={dropdownInfoCreater(
+                        '10rem',
+                        '20.2rem',
+                        '2.3rem',
+                        'middle',
+                        areaData[0]?.usagesList.map((item: any) => item.year),
+                        setCurYear,
+                        setIsYearDropdownOn
+                      )}
+                    ></Dropdown>
+                  )}
+                  {isMonthDropdownOn && (
+                    <Dropdown
+                      dropDownInfo={dropdownInfoCreater(
+                        '10rem',
+                        '27.2rem',
+                        '2.3rem',
+                        'middle',
+                        monthCategory,
+                        setCurMonth,
+                        setIsMonthDropdownOn
+                      )}
+                    ></Dropdown>
+                  )}
+                  <S.ChartTopFrame>
+                    <S.ChartYearBox
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setIsYearDropdownOn(true);
+                      }}
+                    >
+                      {curYear}년 &nbsp;<img src={downArrow}></img>
+                    </S.ChartYearBox>
+                    <S.ChartMonthBox
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setIsMonthDropdownOn(true);
+                      }}
+                    >
+                      {curMonth}월 &nbsp;<img src={downArrow}></img>
+                    </S.ChartMonthBox>
+                  </S.ChartTopFrame>
+                </S.ChartChangeFrame>
+                <Bar
+                  data={chartData}
+                  options={optionsAreaGas}
+                  width="270"
+                  height="250"
+                ></Bar>
+              </S.Container>
             <S.BottomWrapper>
               <S.BottomTitle>
                 해당시기 사용 1위는 '{buildingByIdx[mostWasteIdx]}' 입니다.

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -482,6 +482,12 @@ const optionsArea: any = {
   reponsive: false,
   indexAxis: 'y',
   plugins: {
+    datalabels: {
+      formatter: (value: any, context: any) => {
+        return value?.toLocaleString('ko-KR') + 'Kwh/㎡';
+      },
+      color: '#fff'
+    },
     legend: {
       display: false,
     },
@@ -515,6 +521,12 @@ const optionsAreaGas: any = {
   reponsive: false,
   indexAxis: 'y',
   plugins: {
+    datalabels: {
+      formatter: (value: any, context: any) => {
+        return value?.toLocaleString('ko-KR') + 'm3/㎡';
+      },
+      color: '#fff'
+    },
     legend: {
       display: false,
     },


### PR DESCRIPTION
* 건물별 탄소 배출량 지표의 차트와 유사하게 면적별 전기, 가스 지표 디자인을 수정.
* 해당 지표에 포함된 건물들 정보 표시
---
![스크린샷 2023-06-03 02-29-39](https://github.com/2023-1-Capstone/frontend/assets/76583883/1b1834e9-1ddc-416b-8250-068eaf23a220)
![스크린샷 2023-06-03 02-30-07](https://github.com/2023-1-Capstone/frontend/assets/76583883/bed491c0-91fe-4a55-9574-4fd45169915b)
