### PR TITLE
전체 전기, 가스, 수도에 대한 예측 값 표기

### DIFF
--- a/src/components/BuildingMoreInfo/BuildingMoreInfo.tsx
+++ b/src/components/BuildingMoreInfo/BuildingMoreInfo.tsx
@@ -58,11 +58,12 @@ const MonthlyMoreInfo = ({
 
   useEffect(() => {
     if (chartState) {
-      const chartStateCopy = JSON.parse(JSON.stringify(chartState));
+      const chartStateCopy = JSON.parse(JSON.stringify(chartData));
       const validColor = doughnutColor.map((color: string, idx: number) => {
         if (predictArray && predictArray[idx]?.data) return color;
         return 'rgb(0,0,0,0.1)';
       });
+      chartStateCopy.datasets[0].data = chartState.datasets[0].data;
       chartStateCopy.datasets[0].backgroundColor = validColor;
       chartStateCopy.datasets[0].borderColor = validColor;
       chartStateCopy.labels = monthCategory.map((item: any) => item + '월');

--- a/src/components/BuildingMoreInfo/BuildingMoreInfoGas.tsx
+++ b/src/components/BuildingMoreInfo/BuildingMoreInfoGas.tsx
@@ -46,31 +46,28 @@ const MonthlyMoreInfo = ({
     let count = 0;
     return (
       arr?.reduce((acc: any, cur: any) => {
-        if (cur?.fee) {
-          count++;
-          return acc + cur.fee / (cur.usages * 1000);
-        }
-        return acc;
+        count++;
+        return cur?.fee
+          ? acc + cur.fee / cur.usages
+          : acc + cur.fee_prediction / cur.prediction;
       }, 0) / count
     );
   };
 
   useEffect(() => {
     if (chartState) {
-      const chartStateCopy = JSON.parse(JSON.stringify(chartState));
+      const chartStateCopy = JSON.parse(JSON.stringify(chartData));
       const validColor = doughnutColor.map((color: string, idx: number) => {
         if (predictArray && predictArray[idx]?.data) return color;
         return 'rgb(0,0,0,0.1)';
       });
+      chartStateCopy.datasets[0].data = chartState.datasets[0].data;
       chartStateCopy.datasets[0].backgroundColor = validColor;
       chartStateCopy.datasets[0].borderColor = validColor;
       chartStateCopy.labels = monthCategory.map((item: any) => item + '월');
       const usageArr = chartStateCopy.datasets[0].data;
       const mostWasteMonth = findMostWasteIdx(usageArr) + 1;
-      const totalWatt = usageArr?.reduce(
-        (acc: any, cur: any) => acc + cur * 1000,
-        0
-      );
+      const totalGas = usageArr?.reduce((acc: any, cur: any) => acc + cur, 0);
 
       const targetFeeData = feeData?.filter(
         (item: any) => item.year === parseInt(curYear)
@@ -78,7 +75,7 @@ const MonthlyMoreInfo = ({
 
       setMoreInfo({
         ...moreInfo,
-        totalWatt: totalWatt,
+        totalWatt: totalGas,
         mostWasteMonth: `${mostWasteMonth}월`,
         averageFee: getAverageFee(targetFeeData),
       });

--- a/src/pages/BuildingElectricity/BuildingElectricity.tsx
+++ b/src/pages/BuildingElectricity/BuildingElectricity.tsx
@@ -8,27 +8,21 @@ import Carousel from '../../components/Carousel/Carousel';
 import downArrow from '../../assets/svg/downArrow.svg';
 import { Dropdown } from '../../components/Dropdown/Dropdown';
 import BuildingMoreInfo from '../../components/BuildingMoreInfo/BuildingMoreInfo';
-import {
-  dropdownInfoCreater,
-  createChartCategoryArray,
-  findMostWasteIdx,
-} from './util';
+import { dropdownInfoCreater, createChartCategoryArray } from './util';
 import { chartInfoType, chartInfoUsageType } from '../../type/Types';
 import test from '../../api/test';
 import api from '../../api/api';
-import CategoryNavigation from '../../components/CategoryHeader/CategoryNavigation';
 import {
   monthlyInitData,
   buildingCode,
   electricityChartCategory,
+  optionsBuildingElectricitiy,
   options,
   monthCategory,
   yearCategory,
 } from '../../store/store';
 
 ChartJS.register(Tooltip, Legend);
-
-const arr = ['건물별', '전체', '면적별', '계절별'];
 
 const BuildingElectricity = () => {
   const [selectedBuilding, setSelectedBuilding] = useState<string>('본관');
@@ -133,6 +127,7 @@ const BuildingElectricity = () => {
 
       // 타겟이 예측인지 아닌지 뽑아내서 색깔 변경주기
       chartStateCopy.datasets[0].backgroundColor = target?.map((data: any) => {
+        if (data.prediction && data?.data > data?.prediction) return '#ff6666';
         if (data.data) return 'rgb(91,125,177,0.9)';
         return 'rgb(0,0,0,0.1)';
       });
@@ -195,7 +190,11 @@ const BuildingElectricity = () => {
               width="350"
               height="250"
               data={chartState}
-              options={options}
+              options={
+                chartCategory === '월별 전기 사용량'
+                  ? options
+                  : optionsBuildingElectricitiy
+              }
             ></Bar>
           </S.ChartContainer>
           <S.ChartTitle>

--- a/src/pages/BuildingElectricity/util.ts
+++ b/src/pages/BuildingElectricity/util.ts
@@ -32,7 +32,7 @@ const createChartCategoryArray = (
   chart: chartInfoType[],
   monthCategory: any
 ) => {
-  const yearData = chart.map((item: chartInfoType) => item.year);
+  const yearData = chart.map((item: chartInfoType) => item.year).reverse();
   const yearLabel = yearData.map((year: any) => year.toString());
   const yearTotalWaste = chart.map((item: chartInfoType) =>
     item.usages.reduce((acc: any, cur: any) => {

--- a/src/pages/BuildingGas/BuildingGas.tsx
+++ b/src/pages/BuildingGas/BuildingGas.tsx
@@ -1,8 +1,6 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Wrapper, WrapperInner } from '../../components/Wrapper/Wrapper.style';
-import Header from '../../components/Header/Header';
-import NavigationBar from '../../components/NavigationBar/NavigationBar';
+import { WrapperInner } from '../../components/Wrapper/Wrapper.style';
 import * as S from './BuildingGas.style';
 import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
 import { Bar } from 'react-chartjs-2';
@@ -18,6 +16,7 @@ import {
   buildingCode,
   gasChartCategory,
   optionsGas,
+  optionsBuildingGas,
   monthCategory,
   yearCategory,
 } from '../../store/store';
@@ -52,14 +51,15 @@ const BuildingGas = () => {
     const chartStateCopy = JSON.parse(JSON.stringify(chartState));
     const target = rData.result[rData.result.length - 1].usages;
     chartStateCopy.datasets[0].data = target.map((data: any) => {
-      if (data.prediction) return data.prediction;
-      return data.data;
+      if (data.data) return data.data;
+      return data.prediction;
     });
     //   backgroundColor: ['rgb(75, 192, 192)'],
     setPredictArray(target);
     chartStateCopy.datasets[0].backgroundColor = rData.result[
       rData.result.length - 1
     ].usages.map((data: any) => {
+      if (data.prediction && data?.data > data?.prediction) return '#ff6666';
       if (data.data) return 'rgb(91,125,177,0.9)';
       return 'rgb(0,0,0,0.1)';
     });
@@ -124,6 +124,7 @@ const BuildingGas = () => {
 
       // 타겟이 예측인지 아닌지 뽑아내서 색깔 변경주기
       chartStateCopy.datasets[0].backgroundColor = target?.map((data: any) => {
+        if (data.prediction && data?.data > data?.prediction) return '#ff6666';
         if (data.data) return 'rgb(91,125,177,0.9)';
         return 'rgb(0,0,0,0.1)';
       });
@@ -187,7 +188,11 @@ const BuildingGas = () => {
               width="350"
               height="250"
               data={chartState}
-              options={optionsGas}
+              options={
+                chartCategory === '월별 가스 사용량'
+                  ? optionsGas
+                  : optionsBuildingGas
+              }
             ></Bar>
           </S.ChartContainer>
           <S.ChartTitle>

--- a/src/pages/BuildingGas/util.ts
+++ b/src/pages/BuildingGas/util.ts
@@ -24,7 +24,7 @@ const createChartCategoryArray = (
   chart: chartInfoType[],
   monthCategory: any
 ) => {
-  const yearData = chart.map((item: chartInfoType) => item.year);
+  const yearData = chart.map((item: chartInfoType) => item.year).reverse();
   const yearLabel = yearData.map((year: any) => year.toString());
   const yearTotalWaste = chart.map((item: chartInfoType) =>
     item.usages.reduce((acc: any, cur: any) => {
@@ -42,7 +42,7 @@ const createChartCategoryArray = (
   });
 
   const matchChartCategory: any = {
-    '월별 가스 사용량': ['2023', yearData.reverse(), monthLabel],
+    '월별 가스 사용량': ['2023', yearData, monthLabel],
     '연별 가스 사용량': [
       null,
       null,

--- a/src/pages/ElectricityAll/Component/ElectricityAllMoreInfo.style.tsx
+++ b/src/pages/ElectricityAll/Component/ElectricityAllMoreInfo.style.tsx
@@ -72,6 +72,7 @@ const Container = styled.div`
   width: 33rem;
   height: 33rem;
   top: 1.2rem;
+  margin-bottom: 1rem;
   border-radius: 1rem;
 `;
 

--- a/src/pages/ElectricityAll/Component/ElectricityAllMoreInfo.tsx
+++ b/src/pages/ElectricityAll/Component/ElectricityAllMoreInfo.tsx
@@ -13,6 +13,7 @@ import { findMostWasteIdx } from '../../BuildingElectricity/util';
 import { BuildingElectricityPlugin } from '../../../store/chartPlugin';
 import TransItem from '../../Indicate/Component/TrasnItem/TransItem';
 import { SummaryFrame, Li } from '../../../components/Summary/Summary.style';
+import { getBackgroundColor, findTargetData } from '../util';
 
 ChartJS.register(Tooltip, Legend, ChartDataLabels);
 
@@ -35,8 +36,14 @@ const MonthlyMoreInfo = ({
   useEffect(() => {
     // 도넛 차트에 물 정보 세팅
     const chartStateCopy = JSON.parse(JSON.stringify(chartData));
+    const targetData = findTargetData(curYear, elecInfo)?.feeResponses;
+    const validColor = doughnutColor.map((color: string, idx: number) => {
+      if (targetData && targetData[idx]?.usages) return color;
+      return 'rgb(0,0,0,0.1)';
+    });
     chartStateCopy.datasets[0].data = chartState.datasets[0].data;
-    chartStateCopy.datasets[0].borderColor = doughnutColor;
+    chartStateCopy.datasets[0].backgroundColor = validColor;
+    chartStateCopy.datasets[0].borderColor = validColor;
     chartStateCopy.labels = monthCategory.map((item: any) => item + '월');
 
     //총 사용량 prediction이 들어오면 가스와 함께 수정 해줘야한다.

--- a/src/pages/ElectricityAll/Component/ElectricityAllMoreInfo.tsx
+++ b/src/pages/ElectricityAll/Component/ElectricityAllMoreInfo.tsx
@@ -13,7 +13,7 @@ import { findMostWasteIdx } from '../../BuildingElectricity/util';
 import { BuildingElectricityPlugin } from '../../../store/chartPlugin';
 import TransItem from '../../Indicate/Component/TrasnItem/TransItem';
 import { SummaryFrame, Li } from '../../../components/Summary/Summary.style';
-import { getBackgroundColor, findTargetData } from '../util';
+import { findTargetData } from '../util';
 
 ChartJS.register(Tooltip, Legend, ChartDataLabels);
 
@@ -41,21 +41,22 @@ const MonthlyMoreInfo = ({
       if (targetData && targetData[idx]?.usages) return color;
       return 'rgb(0,0,0,0.1)';
     });
-    chartStateCopy.datasets[0].data = chartState.datasets[0].data;
+    chartStateCopy.datasets[0].data = chartState.datasets[1].data;
     chartStateCopy.datasets[0].backgroundColor = validColor;
     chartStateCopy.datasets[0].borderColor = validColor;
     chartStateCopy.labels = monthCategory.map((item: any) => item + '월');
 
     //총 사용량 prediction이 들어오면 가스와 함께 수정 해줘야한다.
-    const totalWattWaste = chartStateCopy?.datasets[0].data?.reduce(
-      (acc: number, cur: number) => acc + cur,
+    const totalWattWaste = targetData?.reduce(
+      (acc: any, cur: any) =>
+        cur?.usages ? acc + cur?.usages : acc + cur?.prediction,
       0
     );
 
     /**
      * 총 요금 사용량 prediction이 들어오면 수정 해줘야한다.
      */
-    const totalFee = chartState?.datasets[1].data?.reduce(
+    const totalFee = chartState?.datasets[0].data?.reduce(
       (acc: number, cur: number) => {
         if (cur) return acc + cur;
         return acc;

--- a/src/pages/ElectricityAll/ElectricityAll.tsx
+++ b/src/pages/ElectricityAll/ElectricityAll.tsx
@@ -52,15 +52,15 @@ const ElectricityAll = () => {
       electricityInfo
     )?.feeResponses;
     const chartStateCopy = JSON.parse(JSON.stringify(chartState));
-    chartStateCopy.datasets[0].data = targetData?.map((item: any) =>
+    chartStateCopy.datasets[1].data = targetData?.map((item: any) =>
       item?.usages ? item?.usages : item?.prediction
     );
 
     const backgroundColor = getBackgroundColor(targetData);
 
-    chartStateCopy.datasets[0].backgroundColor = backgroundColor;
     chartStateCopy.datasets[1].backgroundColor = backgroundColor;
-    chartStateCopy.datasets[1].data = targetData?.map((item: any) =>
+    chartStateCopy.datasets[0].backgroundColor = backgroundColor;
+    chartStateCopy.datasets[0].data = targetData?.map((item: any) =>
       item?.fee
         ? Math.floor(item?.fee / 10000)
         : Math.floor(item?.fee_prediction / 10000)

--- a/src/pages/ElectricityAll/ElectricityAll.tsx
+++ b/src/pages/ElectricityAll/ElectricityAll.tsx
@@ -1,25 +1,21 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Wrapper, WrapperInner } from '../../components/Wrapper/Wrapper.style';
-import Header from '../../components/Header/Header';
-import NavigationBar from '../../components/NavigationBar/NavigationBar';
+import { WrapperInner } from '../../components/Wrapper/Wrapper.style';
 import * as S from './ElectricityAll.style.';
 import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
-import { Bar, Line } from 'react-chartjs-2';
+import { Bar } from 'react-chartjs-2';
 import downArrow from '../../assets/svg/downArrow.svg';
 import { Dropdown } from '../../components/Dropdown/Dropdown';
-
 import { dropdownInfoCreater } from './util';
-import { chartInfoType, chartInfoUsageType } from '../../type/Types';
 import api from '../../api/api';
 import {
   monthlyInitData,
   optionsElectricityAll,
-  options,
   monthlyInitAllData,
   yearCategory,
 } from '../../store/store';
 import WaterMoreInfo from './Component/ElectricityAllMoreInfo';
+import { getBackgroundColor, findTargetData } from './util';
 
 const waterCategory = ['월별 전기 사용량', '연간 전기 사용량'];
 
@@ -50,20 +46,6 @@ const ElectricityAll = () => {
     else setIsRightDropDownOn(true);
   };
 
-  const getBackgroundColor = (elecInfo: any) => {
-    return elecInfo?.map((item: any) => {
-      if (item?.usages) return 'rgb(91,125,177,0.9)';
-      return 'rgb(0,0,0,0.1)';
-    });
-  };
-
-  const findTargetData = (curYear: string, info: any) => {
-    const targetData = info?.filter(
-      (item: any) => item.year === parseInt(curYear)
-    )[0];
-    return targetData;
-  };
-
   const setMonthChart = () => {
     const targetData = findTargetData(
       rightCategory,
@@ -77,7 +59,7 @@ const ElectricityAll = () => {
     const backgroundColor = getBackgroundColor(targetData);
 
     chartStateCopy.datasets[0].backgroundColor = backgroundColor;
-
+    chartStateCopy.datasets[1].backgroundColor = backgroundColor;
     chartStateCopy.datasets[1].data = targetData?.map((item: any) =>
       item?.fee
         ? Math.floor(item?.fee / 10000)

--- a/src/pages/ElectricityAll/ElectricityAll.tsx
+++ b/src/pages/ElectricityAll/ElectricityAll.tsx
@@ -50,15 +50,11 @@ const ElectricityAll = () => {
     else setIsRightDropDownOn(true);
   };
 
-  const getBackgroundColor = (elecInfo: chartInfoType[]) => {
-    return elecInfo
-      ?.filter(
-        (item: chartInfoType) => item.year === parseInt(rightCategory)
-      )[0]
-      .usages.map((item: chartInfoUsageType) => {
-        if (item?.data) return 'rgb(91,125,177,0.9)';
-        return 'rgb(0,0,0,0.1)';
-      });
+  const getBackgroundColor = (elecInfo: any) => {
+    return elecInfo?.map((item: any) => {
+      if (item?.usages) return 'rgb(91,125,177,0.9)';
+      return 'rgb(0,0,0,0.1)';
+    });
   };
 
   const findTargetData = (curYear: string, info: any) => {
@@ -75,11 +71,17 @@ const ElectricityAll = () => {
     )?.feeResponses;
     const chartStateCopy = JSON.parse(JSON.stringify(chartState));
     chartStateCopy.datasets[0].data = targetData?.map((item: any) =>
-      item?.usages ? item?.usages : 0
+      item?.usages ? item?.usages : item?.prediction
     );
 
+    const backgroundColor = getBackgroundColor(targetData);
+
+    chartStateCopy.datasets[0].backgroundColor = backgroundColor;
+
     chartStateCopy.datasets[1].data = targetData?.map((item: any) =>
-      Math.floor(item?.fee / 10000)
+      item?.fee
+        ? Math.floor(item?.fee / 10000)
+        : Math.floor(item?.fee_prediction / 10000)
     );
 
     setChartState(chartStateCopy);
@@ -101,6 +103,7 @@ const ElectricityAll = () => {
 
   useEffect(() => {
     setMonthChart();
+    console.log(electricityInfo);
     const yearList = electricityInfo?.map((item: any) => item.year).reverse();
     setYearChart();
     setRightDropDown(yearList);

--- a/src/pages/ElectricityAll/util.ts
+++ b/src/pages/ElectricityAll/util.ts
@@ -63,4 +63,24 @@ const createChartCategoryArray = (
   return matchChartCategory;
 };
 
-export { dropdownInfoCreater, createChartCategoryArray, findMostWasteIdx };
+const getBackgroundColor = (elecInfo: any) => {
+  return elecInfo?.map((item: any) => {
+    if (item?.usages) return 'rgba(91,125,177,0.9)';
+    return '#D8D8D8';
+  });
+};
+
+const findTargetData = (curYear: string, info: any) => {
+  const targetData = info?.filter(
+    (item: any) => item.year === parseInt(curYear)
+  )[0];
+  return targetData;
+};
+
+export {
+  dropdownInfoCreater,
+  createChartCategoryArray,
+  findMostWasteIdx,
+  getBackgroundColor,
+  findTargetData,
+};

--- a/src/pages/GasAll/Component/GasAllMoreInfo.style.tsx
+++ b/src/pages/GasAll/Component/GasAllMoreInfo.style.tsx
@@ -72,6 +72,7 @@ const Container = styled.div`
   width: 33rem;
   height: 33rem;
   top: 1.2rem;
+  margin-bottom: 1rem;
   border-radius: 1rem;
 `;
 

--- a/src/pages/GasAll/Component/GasAllMoreInfo.tsx
+++ b/src/pages/GasAll/Component/GasAllMoreInfo.tsx
@@ -35,7 +35,7 @@ const MonthlyMoreInfo = ({
   useEffect(() => {
     // 도넛 차트에 물 정보 세팅
     const chartStateCopy = JSON.parse(JSON.stringify(chartData));
-    chartStateCopy.datasets[0].data = chartState.datasets[0].data;
+    chartStateCopy.datasets[0].data = chartState.datasets[1].data;
     chartStateCopy.datasets[0].borderColor = doughnutColor;
     chartStateCopy.labels = monthCategory.map((item: any) => item + '월');
 

--- a/src/pages/GasAll/Component/GasAllMoreInfo.tsx
+++ b/src/pages/GasAll/Component/GasAllMoreInfo.tsx
@@ -49,8 +49,9 @@ const MonthlyMoreInfo = ({
     console.log(targetData);
 
     //총 사용량 prediction이 들어오면 가스와 함께 수정 해줘야한다.
-    const totalGasWaste = chartStateCopy?.datasets[1]?.data?.reduce(
-      (acc: number, cur: number) => acc + cur,
+    const totalGasWaste = targetData?.reduce(
+      (acc: any, cur: any) =>
+        cur?.usages ? acc + cur?.usages : acc + cur?.prediction,
       0
     );
 

--- a/src/pages/GasAll/Component/GasAllMoreInfo.tsx
+++ b/src/pages/GasAll/Component/GasAllMoreInfo.tsx
@@ -13,6 +13,7 @@ import { findMostWasteIdx } from '../../BuildingElectricity/util';
 import { BuildingGasPlugin } from '../../../store/chartPlugin';
 import TransItem from '../../Indicate/Component/TrasnItem/TransItem';
 import { SummaryFrame, Li } from '../../../components/Summary/Summary.style';
+import { findTargetData } from '../util';
 
 ChartJS.register(Tooltip, Legend, ChartDataLabels);
 
@@ -35,12 +36,20 @@ const MonthlyMoreInfo = ({
   useEffect(() => {
     // 도넛 차트에 물 정보 세팅
     const chartStateCopy = JSON.parse(JSON.stringify(chartData));
+    const targetData = findTargetData(curYear, gasInfo)?.feeResponses;
+    const validColor = doughnutColor.map((color: string, idx: number) => {
+      if (targetData && targetData[idx]?.usages) return color;
+      return 'rgb(0,0,0,0.1)';
+    });
     chartStateCopy.datasets[0].data = chartState.datasets[1].data;
-    chartStateCopy.datasets[0].borderColor = doughnutColor;
+    chartStateCopy.datasets[0].backgroundColor = validColor;
+    chartStateCopy.datasets[0].borderColor = validColor;
     chartStateCopy.labels = monthCategory.map((item: any) => item + '월');
 
+    console.log(targetData);
+
     //총 사용량 prediction이 들어오면 가스와 함께 수정 해줘야한다.
-    const totalGasWaste = chartStateCopy?.datasets[0].data?.reduce(
+    const totalGasWaste = chartStateCopy?.datasets[1]?.data?.reduce(
       (acc: number, cur: number) => acc + cur,
       0
     );
@@ -48,7 +57,7 @@ const MonthlyMoreInfo = ({
     /**
      * 총 요금 사용량 prediction이 들어오면 수정 해줘야한다.
      */
-    const totalFee = chartState?.datasets[1].data?.reduce(
+    const totalFee = chartState?.datasets[0]?.data?.reduce(
       (acc: number, cur: number) => {
         if (cur) return acc + cur;
         return acc;

--- a/src/pages/GasAll/GasAll.style.tsx
+++ b/src/pages/GasAll/GasAll.style.tsx
@@ -13,10 +13,10 @@ const Container = styled.div`
 `;
 
 const ChartContainer = styled.div`
-  width: 35rem;
+  position: relative;
+  width: 36rem;
   left: 50%;
   transform: translateX(-50%);
-  position: relative;
   margin-bottom: 3px;
 `;
 

--- a/src/pages/GasAll/GasAll.tsx
+++ b/src/pages/GasAll/GasAll.tsx
@@ -11,7 +11,7 @@ import api from '../../api/api';
 import {
   monthlyInitData,
   optionsGasAll,
-  monthlyInitWaterData,
+  monthlyInitAllData,
   yearCategory,
 } from '../../store/store';
 import WaterMoreInfo from './Component/GasAllMoreInfo';
@@ -22,7 +22,7 @@ const waterCategory = ['월별 가스 사용량', '연간 가스 사용량'];
 ChartJS.register(Tooltip, Legend);
 
 const GasAll = () => {
-  const [chartState, setChartState] = useState(monthlyInitWaterData);
+  const [chartState, setChartState] = useState(monthlyInitAllData);
   const [yearChartState, setYearChartState] = useState(monthlyInitData);
   const [chartCategory, setChartCategory] =
     useState<string>('월별 가스 사용량');
@@ -49,15 +49,15 @@ const GasAll = () => {
   const setMonthChart = () => {
     const targetData = findTargetData(rightCategory, gasInfo)?.feeResponses;
     const chartStateCopy = JSON.parse(JSON.stringify(chartState));
-    chartStateCopy.datasets[0].data = targetData?.map((item: any) =>
+    chartStateCopy.datasets[1].data = targetData?.map((item: any) =>
       item?.usages ? item?.usages : item?.prediction
     );
 
     const backgroundColor = getBackgroundColor(targetData);
 
-    chartStateCopy.datasets[0].backgroundColor = backgroundColor;
     chartStateCopy.datasets[1].backgroundColor = backgroundColor;
-    chartStateCopy.datasets[1].data = targetData?.map((item: any) =>
+    chartStateCopy.datasets[0].backgroundColor = backgroundColor;
+    chartStateCopy.datasets[0].data = targetData?.map((item: any) =>
       item?.fee
         ? Math.floor(item?.fee / 10000)
         : Math.floor(item?.fee_prediction / 10000)

--- a/src/pages/GasAll/GasAll.tsx
+++ b/src/pages/GasAll/GasAll.tsx
@@ -1,16 +1,12 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Wrapper, WrapperInner } from '../../components/Wrapper/Wrapper.style';
-import Header from '../../components/Header/Header';
-import NavigationBar from '../../components/NavigationBar/NavigationBar';
+import { WrapperInner } from '../../components/Wrapper/Wrapper.style';
 import * as S from './GasAll.style';
 import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
-import { Bar, Line } from 'react-chartjs-2';
+import { Bar } from 'react-chartjs-2';
 import downArrow from '../../assets/svg/downArrow.svg';
 import { Dropdown } from '../../components/Dropdown/Dropdown';
-
 import { dropdownInfoCreater } from './util';
-import { chartInfoType, chartInfoUsageType } from '../../type/Types';
 import api from '../../api/api';
 import {
   monthlyInitData,
@@ -19,6 +15,7 @@ import {
   yearCategory,
 } from '../../store/store';
 import WaterMoreInfo from './Component/GasAllMoreInfo';
+import { findTargetData, getBackgroundColor } from './util';
 
 const waterCategory = ['월별 가스 사용량', '연간 가스 사용량'];
 
@@ -49,33 +46,21 @@ const GasAll = () => {
     else setIsRightDropDownOn(true);
   };
 
-  const getBackgroundColor = (elecInfo: chartInfoType[]) => {
-    return elecInfo
-      ?.filter(
-        (item: chartInfoType) => item.year === parseInt(rightCategory)
-      )[0]
-      .usages.map((item: chartInfoUsageType) => {
-        if (item?.data) return 'rgb(91,125,177,0.9)';
-        return 'rgb(0,0,0,0.1)';
-      });
-  };
-
-  const findTargetData = (curYear: string, info: any) => {
-    const targetData = info?.filter(
-      (item: any) => item.year === parseInt(curYear)
-    )[0];
-    return targetData;
-  };
-
   const setMonthChart = () => {
     const targetData = findTargetData(rightCategory, gasInfo)?.feeResponses;
     const chartStateCopy = JSON.parse(JSON.stringify(chartState));
     chartStateCopy.datasets[0].data = targetData?.map((item: any) =>
-      item?.usages ? item?.usages : 0
+      item?.usages ? item?.usages : item?.prediction
     );
 
+    const backgroundColor = getBackgroundColor(targetData);
+
+    chartStateCopy.datasets[0].backgroundColor = backgroundColor;
+    chartStateCopy.datasets[1].backgroundColor = backgroundColor;
     chartStateCopy.datasets[1].data = targetData?.map((item: any) =>
-      Math.floor(item?.fee / 10000)
+      item?.fee
+        ? Math.floor(item?.fee / 10000)
+        : Math.floor(item?.fee_prediction / 10000)
     );
     setChartState(chartStateCopy);
   };

--- a/src/pages/GasAll/GasAll.tsx
+++ b/src/pages/GasAll/GasAll.tsx
@@ -106,7 +106,7 @@ const GasAll = () => {
           <S.ChartContainer>
             <Bar
               width="350"
-              height="250"
+              height="300"
               data={chartState}
               options={optionsGasAll}
             ></Bar>

--- a/src/pages/GasAll/util.ts
+++ b/src/pages/GasAll/util.ts
@@ -63,4 +63,24 @@ const createChartCategoryArray = (
   return matchChartCategory;
 };
 
-export { dropdownInfoCreater, createChartCategoryArray, findMostWasteIdx };
+const getBackgroundColor = (elecInfo: any) => {
+  return elecInfo?.map((item: any) => {
+    if (item?.usages) return 'rgba(91,125,177,0.9)';
+    return '#D8D8D8';
+  });
+};
+
+const findTargetData = (curYear: string, info: any) => {
+  const targetData = info?.filter(
+    (item: any) => item.year === parseInt(curYear)
+  )[0];
+  return targetData;
+};
+
+export {
+  dropdownInfoCreater,
+  createChartCategoryArray,
+  findMostWasteIdx,
+  getBackgroundColor,
+  findTargetData,
+};

--- a/src/pages/Indicate/Area/electricity/AreaElectricity.tsx
+++ b/src/pages/Indicate/Area/electricity/AreaElectricity.tsx
@@ -123,7 +123,7 @@ const AreaElectricity = () => {
               dropDownInfo={dropdownInfoCreater(
                 '10rem',
                 '0.5rem',
-                '1rem',
+                '3rem',
                 'middle',
                 areaData[0]?.usagesList.map((item: any) => item.year).reverse(),
                 setCurYear,
@@ -136,7 +136,7 @@ const AreaElectricity = () => {
               dropDownInfo={dropdownInfoCreater(
                 '10rem',
                 '8.5rem',
-                '1rem',
+                '3rem',
                 'small',
                 monthCategory,
                 setCurMonth,

--- a/src/pages/Indicate/Area/electricity/Component/AreaElectricityMoreInfo.tsx
+++ b/src/pages/Indicate/Area/electricity/Component/AreaElectricityMoreInfo.tsx
@@ -77,7 +77,7 @@ const AreaElectricityMoreInfo = ({
         </Li>
         <Li>
           1㎡당{' '}
-          {(chartState?.datasets[0].data[mostWasteIdx] * 7000).toLocaleString(
+          {(chartState?.datasets[0].data[mostWasteIdx] * 120).toLocaleString(
             'ko-KR'
           )}
           원 정도를 사용하였습니다.

--- a/src/pages/Indicate/Carbon/All/CarbonAll.tsx
+++ b/src/pages/Indicate/Carbon/All/CarbonAll.tsx
@@ -3,7 +3,10 @@ import { useState } from 'react';
 import { WrapperInner } from '../../../../components/Wrapper/Wrapper.style';
 import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
 import { Bar } from 'react-chartjs-2';
-import { optionsCarbonAll, monthlyInitData } from '../../../../store/store';
+import {
+  optionsCarbonAll,
+  monthlyInitDataCarbonAll,
+} from '../../../../store/store';
 import downArrow from '../../../../assets/svg/downArrow.svg';
 import * as S from './CarbonAll.style';
 import { Dropdown } from '../../../../components/Dropdown/Dropdown';
@@ -25,7 +28,7 @@ const CarbonAll = () => {
 
   const [mostWasteSeasonIdx, setMostWasteSeasonIdx] = useState<number>(0);
   const [mostWaste, setMostWaste] = useState<number>(0);
-  const [chartData, setChartData] = useState(monthlyInitData);
+  const [chartData, setChartData] = useState(monthlyInitDataCarbonAll);
   const [isDropdownOn, setIsDropdownOn] = useState<Boolean>(false);
   const [curYear, setCurYear] = useState<string>('2023');
   const [totalCarbon, setTotalCarbon] = useState(0);

--- a/src/pages/Indicate/Carbon/All/CarbonAll.tsx
+++ b/src/pages/Indicate/Carbon/All/CarbonAll.tsx
@@ -35,7 +35,7 @@ const CarbonAll = () => {
     const chartCopyData = JSON.parse(JSON.stringify(chartData));
     const usages = chartInfo
       ?.filter((item: any) => item.year === parseInt(curYear))[0]
-      .usages.map((item: number) => item / 1000);
+      .usages.map((item: any) => (item ? item?.data / 1000 : 0));
     chartCopyData.datasets[0].data = usages;
     const totalUsage = usages?.reduce(
       (acc: number, cur: number) => acc + cur,
@@ -50,6 +50,8 @@ const CarbonAll = () => {
   };
 
   useEffect(() => {
+    console.log(carbonData);
+
     if (carbonData) {
       setCurYearChart(carbonData);
     }
@@ -113,10 +115,10 @@ const CarbonAll = () => {
           </SummaryFrame>
           <TransItem
             type={'carbon'}
-            waste={totalCarbon}
+            waste={totalCarbon * 1000}
             curYear={curYear}
           ></TransItem>
-          <TreeTransItem carbonWaste={totalCarbon}></TreeTransItem>
+          <TreeTransItem carbonWaste={totalCarbon * 1000}></TreeTransItem>
         </S.BottomWrapper>
       </S.SeasonWrapper>
     </WrapperInner>

--- a/src/pages/Indicate/Season/electricity/Component/SeasonElectricityMoreInfo.style.tsx
+++ b/src/pages/Indicate/Season/electricity/Component/SeasonElectricityMoreInfo.style.tsx
@@ -1,0 +1,399 @@
+import styled from 'styled-components';
+
+const SeasonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const SeasonTitle = styled.div`
+  position: relative;
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 2.4rem;
+  line-height: 2.9rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  color: #ffffff;
+`;
+
+const ChartChangeFrame = styled.div`
+  position: relative;
+  width: fit-content;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+`;
+
+const ChartTopFrame = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 0px;
+  top: 0.4rem;
+  left: 0.7rem;
+  position: relative;
+  margin-bottom: 3.5rem;
+  width: 36rem;
+  height: 2.3rem;
+`;
+
+const ChartTitle = styled.div`
+  position: relative;
+  width: 36rem;
+  padding-bottom: 1.5rem;
+  top: 0.4rem;
+  cursor: pointer;
+  flex-direction: row;
+  border-radius: 0.3rem;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.8rem;
+  line-height: 2rem;
+  /* or 286% */
+
+  display: flex;
+  align-items: center;
+  justify-content: right;
+
+  color: #000000;
+
+  /* Inside auto layout */
+  right: 1rem;
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const ChartCategoryBox = styled.div`
+  position: absolute;
+
+  width: fit-content;
+  height: 2.7rem;
+
+  &:hover {
+    background-color: #e7e7e7;
+  }
+  border: 1px solid #e7e7e7;
+
+  cursor: pointer;
+
+  left: -0.5rem;
+  padding: 5px;
+  border-radius: 0.3rem;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 1.7rem;
+  display: flex;
+  align-items: center;
+  opacity: 0.7;
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const ChartYearBox = styled.div`
+  position: absolute;
+  width: 7.5rem;
+  height: 2.7rem;
+  padding: 5px;
+
+  &:hover {
+    background-color: #e7e7e7;
+  }
+
+  border: 1px solid #e7e7e7;
+
+  cursor: pointer;
+
+  left: 9.7rem;
+
+  border-radius: 0.3rem;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 2rem;
+  /* or 286% */
+
+  display: flex;
+  align-items: center;
+  text-align: center;
+  opacity: 0.7;
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const ChartIndicatorLine = styled.div`
+  position: relative;
+  width: 7.6rem;
+  height: 0px;
+  border: 0.1rem solid #757575;
+`;
+
+const BottomWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 36rem;
+  height: 68.5rem;
+  background: #f5f5f5;
+  border-radius: 0.5rem;
+`;
+
+const BottomTitle = styled.div`
+  width: 26.5rem;
+  height: 2.6rem;
+  margin-top: 1.2rem;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.5rem;
+  line-height: 1.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #000000;
+`;
+
+const BottomInfoBoxInner = styled.div`
+  position: relative;
+  width: 33rem;
+  height: fit-content;
+  display: flex;
+  flex-direction: column;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.5rem;
+  /* or 164% */
+
+  border: 2px solid #fff;
+  background-color: #eee;
+  border-radius: 1rem;
+  padding: 1rem;
+  letter-spacing: 0.02rem;
+  position: relative;
+
+  /* Black/600 */
+  gap: 0.8rem;
+  color: #757575;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const Li = styled.li`
+  padding-left: 21px;
+  text-indent: -1.8rem;
+`;
+
+const BottomInfoTransWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  padding: 0rem;
+  gap: 0.6rem;
+
+  width: 28.8rem;
+  height: fit-content;
+
+  flex-wrap: wrap;
+`;
+
+const RefreshButton = styled.img`
+  width: 2.5rem;
+  height: 2.5rem;
+  cursor: pointer;
+`;
+const Container = styled.div`
+  background-color: #ffffff;
+  top: 0rem;
+  position: relative;
+  width: 36rem;
+  height: fit-content;
+  border-radius: 0.5rem;
+  margin-bottom: 0rem;
+`;
+const BuildingMoreInfoTitle = styled.div`
+  position: relative;
+  width: fit-content;
+  height: 2.6rem;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 2rem;
+  display: flex;
+  margin-top: 1rem;
+  align-items: center;
+  opacity: 0.7;
+  color: #000000;
+`;
+
+const Calculate = styled.div`
+  position: relative;
+  height: fit-content;
+  width: 36rem;
+  display: flex;
+  align-items: center;
+  text-align: right;
+  font-size: 1.7rem;
+  justify-content: flex-end;
+  margin-top: -1rem;
+  color: #fff;
+  font-weight: 400;
+`;
+
+const InfoImage = styled.img`
+  width: 2rem;
+  height: 2rem;
+  background: url(${(props) => props.src});
+  cursor: pointer;
+`;
+
+const BuildingInfoFrame = styled.div<{ modalState: string }>`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: fit-content;
+  top: 9rem;
+  right: 1.5rem;
+  height: fit-content;
+  border-radius: 0.5rem;
+  background-color: #fefbf6;
+  border: 2px solid #eee;
+  padding: 1rem;
+  z-index: 2;
+  visibility: ${(props) => props.modalState};
+`;
+
+const BuildingInfoNotice = styled.div`
+  position: relative;
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 17px;
+
+  color: #757575;
+`;
+
+const BuildingInfoItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 0.2rem;
+
+  position: relative;
+  width: 33rem;
+  height: fit-content;
+  margin-bottom: ;
+`;
+
+const BuildingInfoItemTitle = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 19px;
+
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const BuildingInfoItemContent = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 17px;
+
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const SeasonInfoDescriptionFrame = styled.div`
+  position: relative;
+  left: 1rem;
+  display: flex;
+  flex-direction: row;
+  gap: 4rem;
+  justify-content: center;
+`;
+
+const SeasonInfoDescriptionItem = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export {
+  SeasonWrapper,
+  ChartCategoryBox,
+  ChartIndicatorLine,
+  ChartYearBox,
+  ChartTopFrame,
+  ChartChangeFrame,
+  BottomWrapper,
+  BottomTitle,
+  BottomInfoBoxInner,
+  BottomInfoTransWrapper,
+  SeasonTitle,
+  RefreshButton,
+  Container,
+  BuildingMoreInfoTitle,
+  Li,
+  Calculate,
+  InfoImage,
+  BuildingInfoFrame,
+  BuildingInfoItemContent,
+  BuildingInfoNotice,
+  BuildingInfoItemTitle,
+  BuildingInfoItem,
+  SeasonInfoDescriptionFrame,
+  SeasonInfoDescriptionItem,
+};

--- a/src/pages/Indicate/Season/electricity/Component/SeasonElectricityMoreInfo.tsx
+++ b/src/pages/Indicate/Season/electricity/Component/SeasonElectricityMoreInfo.tsx
@@ -1,0 +1,79 @@
+import { useState, useEffect } from 'react';
+import * as S from './SeasonElectricityMoreInfo.style';
+import { Doughnut } from 'react-chartjs-2';
+import {
+  optionsDoughnut,
+  seasonInitDataDoughnut,
+  season,
+} from '../../../../../store/store';
+import { BuildingElectricityPlugin } from '../../../../../store/chartPlugin';
+import {
+  SummaryFrame,
+  Li,
+} from '../../../../../components/Summary/Summary.style';
+import TransItem from '../../../Component/TrasnItem/TransItem';
+
+const SeasonElectricityMoreInfo = ({
+  chartState,
+  curYear,
+  mostWasteSeasonIdx,
+  infoData,
+}: {
+  chartState: any;
+  curYear: any;
+  mostWasteSeasonIdx: any;
+  infoData: any;
+}) => {
+  const [chartData, setChartData] = useState(seasonInitDataDoughnut);
+  const getPercent = (usageArr: number[], targetUsage: number) => {
+    let numOfNotNullSeason = 0;
+    const averageWatt = Math.floor(
+      usageArr.reduce((acc: number, cur: number) => {
+        if (cur !== 0) numOfNotNullSeason++;
+        return acc + cur;
+      }, 0) / numOfNotNullSeason
+    );
+    return ((targetUsage / averageWatt) * 10).toFixed(2);
+  };
+
+  useEffect(() => {
+    const chartDataCopy = JSON.parse(JSON.stringify(chartData));
+    chartDataCopy.datasets[0].data = chartState.datasets[0].data;
+    setChartData(chartDataCopy);
+  }, [chartState]);
+
+  return (
+    <S.BottomWrapper>
+      <S.BuildingMoreInfoTitle>요약 정보</S.BuildingMoreInfoTitle>
+      <S.ChartIndicatorLine></S.ChartIndicatorLine>
+      <Doughnut
+        options={optionsDoughnut}
+        data={chartData}
+        plugins={[BuildingElectricityPlugin]}
+      ></Doughnut>
+      <SummaryFrame>
+        <Li>
+          해당년도 사용 1위는 '{season[mostWasteSeasonIdx]}'이며 계절 평균 대비
+          &nbsp;
+          {getPercent(chartData?.datasets[0].data, infoData?.watt)}%가 높습니다.
+        </Li>
+        <Li>
+          총 사용 전기량은 &nbsp;
+          {(infoData.watt * 1000).toLocaleString('ko-KR')}
+          kwh 입니다.
+        </Li>
+        <Li>
+          예상 사용 요금은 &nbsp;
+          {Math.floor(infoData.fee).toLocaleString('ko-KR')}원 입니다.
+        </Li>
+      </SummaryFrame>
+      <TransItem
+        curYear={curYear}
+        type={'resource'}
+        waste={infoData.fee}
+      ></TransItem>
+    </S.BottomWrapper>
+  );
+};
+
+export default SeasonElectricityMoreInfo;

--- a/src/pages/Indicate/Season/electricity/SeasonElectricity.tsx
+++ b/src/pages/Indicate/Season/electricity/SeasonElectricity.tsx
@@ -17,11 +17,8 @@ import { dropdownInfoCreater } from '../../../BuildingElectricity/util';
 import { useQuery } from '@tanstack/react-query';
 import { getAverageFee, findMostWasteIdx } from '../util';
 import api from '../../../../api/api';
-import TransItem from '../../Component/TrasnItem/TransItem';
-import { getUniqueNumberList } from '../util';
-import { BuildingElectricityPlugin } from '../../../../store/chartPlugin';
 import informationSVG from '../../../../assets/svg/information.svg';
-import { SummaryFrame, Li } from '../../../../components/Summary/Summary.style';
+import SeasonElectricityMoreInfo from './Component/SeasonElectricityMoreInfo';
 
 ChartJS.register(Tooltip, Legend);
 
@@ -47,9 +44,6 @@ const SeasonElectricity = () => {
 
   const [mostWasteSeasonIdx, setMostWasteSeasonIdx] = useState<number>(0);
   const [chartData, setChartData] = useState(seasonInitData);
-  const [chartDataDoughnut, setChartDataDoughtnut] = useState(
-    seasonInitDataDoughnut
-  );
   const [isDropdownOn, setIsDropdownOn] = useState<Boolean>(false);
   const [yearList, setYearList] = useState([]);
   const [curYear, setCurYear] = useState<string>('');
@@ -76,23 +70,19 @@ const SeasonElectricity = () => {
       );
       // 차트 정보 세팅
       const chartDataCopy = JSON.parse(JSON.stringify(chartData));
-      const chartDataDoughnutCopy = JSON.parse(
-        JSON.stringify(chartDataDoughnut)
-      );
+
       const usageList = validData[validData.length - 1].usages;
       chartDataCopy.datasets[0].data = usageList.filter(
         (val: number) => val !== 0
       );
-      chartDataDoughnut.datasets[0].data = usageList.filter(
-        (val: number) => val !== 0
-      );
-      setChartData(chartDataCopy);
-      setChartDataDoughtnut(chartDataDoughnutCopy);
+
       //유효하지 않은 계절 제거
       const validSeason = usageList
         .filter((item: any) => item !== 0)
         .map((item: any, idx: number) => seasonInfo[idx].season);
       chartDataCopy.labels = validSeason;
+
+      setChartData(chartDataCopy);
 
       // 가장 사용을 많이 한 계절 인덱스 탐색
       const targetSeasonIdx = findMostWasteIdx(validData);
@@ -228,37 +218,12 @@ const SeasonElectricity = () => {
             options={optionsSeason}
           ></Bar>
         </S.Container>
-        <S.BottomWrapper>
-          <S.BuildingMoreInfoTitle>요약 정보</S.BuildingMoreInfoTitle>
-          <S.ChartIndicatorLine></S.ChartIndicatorLine>
-          <Doughnut
-            options={optionsDoughnut}
-            data={chartDataDoughnut}
-            plugins={[BuildingElectricityPlugin]}
-          ></Doughnut>
-          <SummaryFrame>
-            <Li>
-              해당년도 사용 1위는 '{season[mostWasteSeasonIdx]}'이며 계절 평균
-              대비 &nbsp;
-              {getPercent(chartData?.datasets[0].data, infoData?.watt)}%가
-              높습니다.
-            </Li>
-            <Li>
-              총 사용 전기량은 &nbsp;
-              {(infoData.watt * 1000).toLocaleString('ko-KR')}
-              kwh 입니다.
-            </Li>
-            <Li>
-              예상 사용 요금은 &nbsp;
-              {Math.floor(infoData.fee).toLocaleString('ko-KR')}원 입니다.
-            </Li>
-          </SummaryFrame>
-          <TransItem
-            curYear={curYear}
-            type={'resource'}
-            waste={infoData.fee}
-          ></TransItem>
-        </S.BottomWrapper>
+        <SeasonElectricityMoreInfo
+          chartState={chartData}
+          mostWasteSeasonIdx={mostWasteSeasonIdx}
+          infoData={infoData}
+          curYear={curYear}
+        ></SeasonElectricityMoreInfo>
       </S.SeasonWrapper>
     </WrapperInner>
   );

--- a/src/pages/Indicate/Season/electricity/SeasonElectricity.tsx
+++ b/src/pages/Indicate/Season/electricity/SeasonElectricity.tsx
@@ -8,6 +8,7 @@ import {
   seasonInitData,
   season,
   optionsDoughnut,
+  seasonInitDataDoughnut,
 } from '../../../../store/store';
 import downArrow from '../../../../assets/svg/downArrow.svg';
 import * as S from './SeasonElectricity.style';
@@ -46,13 +47,13 @@ const SeasonElectricity = () => {
 
   const [mostWasteSeasonIdx, setMostWasteSeasonIdx] = useState<number>(0);
   const [chartData, setChartData] = useState(seasonInitData);
+  const [chartDataDoughnut, setChartDataDoughtnut] = useState(
+    seasonInitDataDoughnut
+  );
   const [isDropdownOn, setIsDropdownOn] = useState<Boolean>(false);
   const [yearList, setYearList] = useState([]);
   const [curYear, setCurYear] = useState<string>('');
   const [infoData, setInfoData] = useState({ watt: 0, fee: 0 });
-  const [randomIdxList, setRandomIdxList] = useState<number[]>(
-    getUniqueNumberList(4, 6)
-  );
   const [infoModalState, setInfoModalState] = useState<string>('hidden');
 
   const getPercent = (usageArr: number[], targetUsage: number) => {
@@ -75,12 +76,18 @@ const SeasonElectricity = () => {
       );
       // 차트 정보 세팅
       const chartDataCopy = JSON.parse(JSON.stringify(chartData));
+      const chartDataDoughnutCopy = JSON.parse(
+        JSON.stringify(chartDataDoughnut)
+      );
       const usageList = validData[validData.length - 1].usages;
       chartDataCopy.datasets[0].data = usageList.filter(
         (val: number) => val !== 0
       );
+      chartDataDoughnut.datasets[0].data = usageList.filter(
+        (val: number) => val !== 0
+      );
       setChartData(chartDataCopy);
-
+      setChartDataDoughtnut(chartDataDoughnutCopy);
       //유효하지 않은 계절 제거
       const validSeason = usageList
         .filter((item: any) => item !== 0)
@@ -226,7 +233,7 @@ const SeasonElectricity = () => {
           <S.ChartIndicatorLine></S.ChartIndicatorLine>
           <Doughnut
             options={optionsDoughnut}
-            data={chartData}
+            data={chartDataDoughnut}
             plugins={[BuildingElectricityPlugin]}
           ></Doughnut>
           <SummaryFrame>

--- a/src/pages/Indicate/Season/gas/SeasonGas.tsx
+++ b/src/pages/Indicate/Season/gas/SeasonGas.tsx
@@ -2,13 +2,11 @@ import { useEffect } from 'react';
 import { useState } from 'react';
 import { WrapperInner } from '../../../../components/Wrapper/Wrapper.style';
 import { Chart as ChartJS, Tooltip, Legend } from 'chart.js/auto';
-import { Bar, Doughnut } from 'react-chartjs-2';
+import { Bar } from 'react-chartjs-2';
 import {
-  optionsGas,
+  optionsSeasonGas,
   seasonInitData,
   seasonInitDataDoughnut,
-  season,
-  optionsDoughnut,
 } from '../../../../store/store';
 import downArrow from '../../../../assets/svg/downArrow.svg';
 import * as S from './SeasonGas.style';
@@ -17,10 +15,8 @@ import { dropdownInfoCreater } from '../../../BuildingElectricity/util';
 import { useQuery } from '@tanstack/react-query';
 import { getAverageFee, findMostWasteIdx } from '../util';
 import api from '../../../../api/api';
-import TransItem from '../../Component/TrasnItem/TransItem';
 import informationSVG from '../../../../assets/svg/information.svg';
-import { BuildingGasPlugin } from '../../../../store/chartPlugin';
-import { SummaryFrame, Li } from '../../../../components/Summary/Summary.style';
+import SeasonGasMoreInfo from './SeasonGasMoreInfo/SeasonGasMoreInfo';
 
 ChartJS.register(Tooltip, Legend);
 
@@ -225,38 +221,15 @@ const SeasonGas = () => {
             width="350"
             height="250"
             data={chartData}
-            options={optionsGas}
+            options={optionsSeasonGas}
           ></Bar>
         </S.Container>
-        <S.BottomWrapper>
-          <S.BuildingMoreInfoTitle>요약 정보</S.BuildingMoreInfoTitle>
-          <S.ChartIndicatorLine></S.ChartIndicatorLine>
-          <Doughnut
-            options={optionsDoughnut}
-            data={chartDataDoughnut}
-            plugins={[BuildingGasPlugin]}
-          ></Doughnut>
-          <SummaryFrame>
-            <Li>
-              해당년도 사용 1위는 '{season[mostWasteSeasonIdx]}'이며 계절 평균
-              대비 &nbsp;
-              {getPercent(chartData?.datasets[0].data, infoData?.watt)}%가
-              높습니다.
-            </Li>
-            <Li>
-              총 사용량은 {infoData.watt.toLocaleString('ko-KR')}m3 입니다.
-            </Li>
-            <Li>
-              예상 사용 요금은 &nbsp;
-              {Math.floor(infoData.fee).toLocaleString('ko-KR')}원 입니다.
-            </Li>
-          </SummaryFrame>
-          <TransItem
-            type={'resource'}
-            waste={infoData.fee}
-            curYear={curYear}
-          ></TransItem>
-        </S.BottomWrapper>
+        <SeasonGasMoreInfo
+          chartState={chartData}
+          curYear={curYear}
+          mostWasteSeasonIdx={mostWasteSeasonIdx}
+          infoData={infoData}
+        ></SeasonGasMoreInfo>
       </S.SeasonWrapper>
     </WrapperInner>
   );

--- a/src/pages/Indicate/Season/gas/SeasonGas.tsx
+++ b/src/pages/Indicate/Season/gas/SeasonGas.tsx
@@ -6,6 +6,7 @@ import { Bar, Doughnut } from 'react-chartjs-2';
 import {
   optionsGas,
   seasonInitData,
+  seasonInitDataDoughnut,
   season,
   optionsDoughnut,
 } from '../../../../store/store';
@@ -18,7 +19,6 @@ import { getAverageFee, findMostWasteIdx } from '../util';
 import api from '../../../../api/api';
 import TransItem from '../../Component/TrasnItem/TransItem';
 import informationSVG from '../../../../assets/svg/information.svg';
-import { getUniqueNumberList } from '../util';
 import { BuildingGasPlugin } from '../../../../store/chartPlugin';
 import { SummaryFrame, Li } from '../../../../components/Summary/Summary.style';
 
@@ -46,14 +46,14 @@ const SeasonGas = () => {
 
   const [mostWasteSeasonIdx, setMostWasteSeasonIdx] = useState<number>(0);
   const [chartData, setChartData] = useState(seasonInitData);
+  const [chartDataDoughnut, setChartDataDoughtnut] = useState(
+    seasonInitDataDoughnut
+  );
   const [yearList, setYearList] = useState([]);
   const [isDropdownOn, setIsDropdownOn] = useState<Boolean>(false);
   const [curYear, setCurYear] = useState<string>('2023');
   const [infoData, setInfoData] = useState({ watt: 0, fee: 0 });
   const [infoModalState, setInfoModalState] = useState<string>('hidden');
-  const [randomIdxList, setRandomIdxList] = useState<number[]>(
-    getUniqueNumberList(4, 6)
-  );
 
   const getPercent = (usageArr: number[], targetUsage: number) => {
     let numOfNotNullSeason = 0;
@@ -76,8 +76,14 @@ const SeasonGas = () => {
       );
       // 차트 정보 세팅
       const chartDataCopy = JSON.parse(JSON.stringify(chartData));
+      const chartDataDoughnutCopy = JSON.parse(
+        JSON.stringify(chartDataDoughnut)
+      );
       const usageList = validData[validData.length - 1].usages;
       chartDataCopy.datasets[0].data = usageList.filter(
+        (val: number) => val !== 0
+      );
+      chartDataDoughnut.datasets[0].data = usageList.filter(
         (val: number) => val !== 0
       );
       setChartData(chartDataCopy);
@@ -227,7 +233,7 @@ const SeasonGas = () => {
           <S.ChartIndicatorLine></S.ChartIndicatorLine>
           <Doughnut
             options={optionsDoughnut}
-            data={chartData}
+            data={chartDataDoughnut}
             plugins={[BuildingGasPlugin]}
           ></Doughnut>
           <SummaryFrame>

--- a/src/pages/Indicate/Season/gas/SeasonGasMoreInfo/SeasonGasMoreInfo.style.tsx
+++ b/src/pages/Indicate/Season/gas/SeasonGasMoreInfo/SeasonGasMoreInfo.style.tsx
@@ -1,0 +1,399 @@
+import styled from 'styled-components';
+
+const SeasonWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const SeasonTitle = styled.div`
+  position: relative;
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 2.4rem;
+  line-height: 2.9rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+  color: #ffffff;
+`;
+
+const ChartChangeFrame = styled.div`
+  position: relative;
+  width: fit-content;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+`;
+
+const ChartTopFrame = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 0px;
+  top: 0.4rem;
+  left: 0.7rem;
+  position: relative;
+  margin-bottom: 3.5rem;
+  width: 36rem;
+  height: 2.3rem;
+`;
+
+const ChartTitle = styled.div`
+  position: relative;
+  width: 36rem;
+  padding-bottom: 1.5rem;
+  top: 0.4rem;
+  cursor: pointer;
+  flex-direction: row;
+  border-radius: 0.3rem;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.8rem;
+  line-height: 2rem;
+  /* or 286% */
+
+  display: flex;
+  align-items: center;
+  justify-content: right;
+
+  color: #000000;
+
+  /* Inside auto layout */
+  right: 1rem;
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const ChartCategoryBox = styled.div`
+  position: absolute;
+
+  width: fit-content;
+  height: 2.7rem;
+
+  &:hover {
+    background-color: #e7e7e7;
+  }
+  border: 1px solid #e7e7e7;
+
+  cursor: pointer;
+
+  left: -0.5rem;
+  padding: 5px;
+  border-radius: 0.3rem;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 1.7rem;
+  display: flex;
+  align-items: center;
+  opacity: 0.7;
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const ChartYearBox = styled.div`
+  position: absolute;
+  width: 7.5rem;
+  height: 2.7rem;
+  padding: 5px;
+
+  &:hover {
+    background-color: #e7e7e7;
+  }
+
+  border: 1px solid #e7e7e7;
+
+  cursor: pointer;
+
+  left: 9.7rem;
+
+  border-radius: 0.3rem;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 2rem;
+  /* or 286% */
+
+  display: flex;
+  align-items: center;
+  text-align: center;
+  opacity: 0.7;
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const ChartIndicatorLine = styled.div`
+  position: relative;
+  width: 7.6rem;
+  height: 0px;
+  border: 0.1rem solid #757575;
+`;
+
+const BottomWrapper = styled.div`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 36rem;
+  height: 68.5rem;
+  background: #f5f5f5;
+  border-radius: 0.5rem;
+`;
+
+const BottomTitle = styled.div`
+  width: 26.5rem;
+  height: 2.6rem;
+  margin-top: 1.2rem;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.5rem;
+  line-height: 1.8rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: #000000;
+`;
+
+const BottomInfoBoxInner = styled.div`
+  position: relative;
+  width: 33rem;
+  height: fit-content;
+  display: flex;
+  flex-direction: column;
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.5rem;
+  /* or 164% */
+
+  border: 2px solid #fff;
+  background-color: #eee;
+  border-radius: 1rem;
+  padding: 1rem;
+  letter-spacing: 0.02rem;
+  position: relative;
+
+  /* Black/600 */
+  gap: 0.8rem;
+  color: #757575;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const Li = styled.li`
+  padding-left: 21px;
+  text-indent: -1.8rem;
+`;
+
+const BottomInfoTransWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+
+  padding: 0rem;
+  gap: 0.6rem;
+
+  width: 28.8rem;
+  height: fit-content;
+
+  flex-wrap: wrap;
+`;
+
+const RefreshButton = styled.img`
+  width: 2.5rem;
+  height: 2.5rem;
+  cursor: pointer;
+`;
+const Container = styled.div`
+  background-color: #ffffff;
+  top: 0rem;
+  position: relative;
+  width: 36rem;
+  height: fit-content;
+  border-radius: 0.5rem;
+  margin-bottom: 0rem;
+`;
+const BuildingMoreInfoTitle = styled.div`
+  position: relative;
+  width: fit-content;
+  height: 2.6rem;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 2rem;
+  display: flex;
+  margin-top: 1rem;
+  align-items: center;
+  opacity: 0.7;
+  color: #000000;
+`;
+
+const Calculate = styled.div`
+  position: relative;
+  height: fit-content;
+  width: 36rem;
+  display: flex;
+  align-items: center;
+  text-align: right;
+  font-size: 1.7rem;
+  justify-content: flex-end;
+  margin-top: -1rem;
+  color: #fff;
+  font-weight: 400;
+`;
+
+const InfoImage = styled.img`
+  width: 2rem;
+  height: 2rem;
+  background: url(${(props) => props.src});
+  cursor: pointer;
+`;
+
+const BuildingInfoFrame = styled.div<{ modalState: string }>`
+  position: absolute;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: fit-content;
+  top: 9rem;
+  right: 1.5rem;
+  height: fit-content;
+  border-radius: 0.5rem;
+  background-color: #fefbf6;
+  border: 2px solid #eee;
+  padding: 1rem;
+  z-index: 2;
+  visibility: ${(props) => props.modalState};
+`;
+
+const BuildingInfoNotice = styled.div`
+  position: relative;
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 17px;
+
+  color: #757575;
+`;
+
+const BuildingInfoItem = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0px;
+  gap: 0.2rem;
+
+  position: relative;
+  width: 33rem;
+  height: fit-content;
+  margin-bottom: ;
+`;
+
+const BuildingInfoItemTitle = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 700;
+  font-size: 1.6rem;
+  line-height: 19px;
+
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const BuildingInfoItemContent = styled.div`
+  width: fit-content;
+  height: fit-content;
+
+  font-family: 'Pretendard';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 1.4rem;
+  line-height: 17px;
+
+  color: #000000;
+
+  /* Inside auto layout */
+
+  flex: none;
+  order: 0;
+  flex-grow: 0;
+`;
+
+const SeasonInfoDescriptionFrame = styled.div`
+  position: relative;
+  left: 1rem;
+  display: flex;
+  flex-direction: row;
+  gap: 4rem;
+  justify-content: center;
+`;
+
+const SeasonInfoDescriptionItem = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export {
+  SeasonWrapper,
+  ChartCategoryBox,
+  ChartIndicatorLine,
+  ChartYearBox,
+  ChartTopFrame,
+  ChartChangeFrame,
+  BottomWrapper,
+  BottomTitle,
+  BottomInfoBoxInner,
+  BottomInfoTransWrapper,
+  SeasonTitle,
+  RefreshButton,
+  Container,
+  BuildingMoreInfoTitle,
+  Li,
+  Calculate,
+  InfoImage,
+  BuildingInfoFrame,
+  BuildingInfoItemContent,
+  BuildingInfoNotice,
+  BuildingInfoItemTitle,
+  BuildingInfoItem,
+  SeasonInfoDescriptionFrame,
+  SeasonInfoDescriptionItem,
+};

--- a/src/pages/Indicate/Season/gas/SeasonGasMoreInfo/SeasonGasMoreInfo.tsx
+++ b/src/pages/Indicate/Season/gas/SeasonGasMoreInfo/SeasonGasMoreInfo.tsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react';
+import * as S from './SeasonGasMoreInfo.style';
+import { Doughnut } from 'react-chartjs-2';
+import {
+  optionsDoughnut,
+  seasonInitDataDoughnut,
+  season,
+} from '../../../../../store/store';
+import { BuildingGasPlugin } from '../../../../../store/chartPlugin';
+import {
+  SummaryFrame,
+  Li,
+} from '../../../../../components/Summary/Summary.style';
+import TransItem from '../../../Component/TrasnItem/TransItem';
+
+const SeasonGasMoreInfo = ({
+  chartState,
+  curYear,
+  mostWasteSeasonIdx,
+  infoData,
+}: {
+  chartState: any;
+  curYear: any;
+  mostWasteSeasonIdx: any;
+  infoData: any;
+}) => {
+  const [chartData, setChartData] = useState(seasonInitDataDoughnut);
+  const getPercent = (usageArr: number[], targetUsage: number) => {
+    let numOfNotNullSeason = 0;
+    const averageWatt = Math.floor(
+      usageArr.reduce((acc: number, cur: number) => {
+        if (cur !== 0) numOfNotNullSeason++;
+        return acc + cur;
+      }, 0) / numOfNotNullSeason
+    );
+    return ((targetUsage / averageWatt) * 10).toFixed(2);
+  };
+
+  useEffect(() => {
+    const chartDataCopy = JSON.parse(JSON.stringify(chartData));
+    chartDataCopy.datasets[0].data = chartState.datasets[0].data;
+    setChartData(chartDataCopy);
+  }, [chartState]);
+
+  return (
+    <S.BottomWrapper>
+      <S.BuildingMoreInfoTitle>요약 정보</S.BuildingMoreInfoTitle>
+      <S.ChartIndicatorLine></S.ChartIndicatorLine>
+      <Doughnut
+        options={optionsDoughnut}
+        data={chartData}
+        plugins={[BuildingGasPlugin]}
+      ></Doughnut>
+      <SummaryFrame>
+        <Li>
+          해당년도 사용 1위는 '{season[mostWasteSeasonIdx]}'이며 계절 평균 대비
+          &nbsp;
+          {getPercent(chartData?.datasets[0].data, infoData?.watt)}%가 높습니다.
+        </Li>
+        <Li>총 사용량은 {infoData.watt.toLocaleString('ko-KR')}m3 입니다.</Li>
+        <Li>
+          예상 사용 요금은 &nbsp;
+          {Math.floor(infoData.fee).toLocaleString('ko-KR')}원 입니다.
+        </Li>
+      </SummaryFrame>
+      <TransItem
+        type={'resource'}
+        waste={infoData.fee}
+        curYear={curYear}
+      ></TransItem>
+    </S.BottomWrapper>
+  );
+};
+
+export default SeasonGasMoreInfo;

--- a/src/pages/Water/Water.style.tsx
+++ b/src/pages/Water/Water.style.tsx
@@ -116,7 +116,7 @@ const ChartCategoryBox = styled.div`
   align-items: center;
 
   color: #000000;
-
+  opacity: 0.7;
   /* Inside auto layout */
 
   flex: none;
@@ -126,7 +126,7 @@ const ChartCategoryBox = styled.div`
 
 const ChartYearBox = styled.div`
   position: absolute;
-  width: fit-content;
+  width: 7.5rem;
   height: 2.7rem;
   padding: 5px;
 
@@ -153,7 +153,7 @@ const ChartYearBox = styled.div`
   text-align: center;
 
   color: #000000;
-
+  opacity: 0.7;
   /* Inside auto layout */
 
   flex: none;

--- a/src/pages/Water/Water.tsx
+++ b/src/pages/Water/Water.tsx
@@ -55,9 +55,9 @@ const Water = () => {
       ?.filter(
         (item: chartInfoType) => item.year === parseInt(rightCategory)
       )[0]
-      ?.usages.map((item: chartInfoUsageType) => {
+      ?.usages?.map((item: chartInfoUsageType) => {
         if (item?.data) return 'rgb(91,125,177,0.9)';
-        return 'rgb(0,0,0,0.1)';
+        return '#D8D8D8';
       });
   };
 
@@ -79,13 +79,16 @@ const Water = () => {
 
     // 요금 리스트 뽑기
     const feeList = targetData?.usages.map((item: any) =>
-      Math.floor(item.fee / 10000)
+      item?.fee
+        ? Math.floor(item.fee / 10000)
+        : Math.floor(item.fee_prediction / 10000)
     );
 
     //요금 리스트 세팅
     chartStateCopy.datasets[1].data = feeList;
+    chartStateCopy.datasets[1].backgroundColor = backgroundColor;
     setChartState(chartStateCopy);
-    setRightDropDown(yearList);
+    setRightDropDown(yearList?.reverse());
   }, [waterInfo, rightCategory]);
 
   useEffect(() => {

--- a/src/store/chartPlugin.ts
+++ b/src/store/chartPlugin.ts
@@ -41,9 +41,10 @@ const BuildingElectricityPlugin = {
     } = chart;
 
     let total = 0;
-
     chart.data.datasets.forEach((dataset: any, idx: number) => {
-      total = dataset.data?.reduce((acc: number, cur: number) => acc + cur, 0);
+      total = dataset.data?.reduce((acc: number, cur: number) => {
+        return acc + cur;
+      }, 0);
     });
 
     ctx.save();

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -108,6 +108,7 @@ const monthlyInitWaterData: any = {
       yAxisID: 'y-left',
       maxBarThickness: 35,
       borderRadius: 3,
+      label: '사용량',
       data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
     },
     {
@@ -117,7 +118,16 @@ const monthlyInitWaterData: any = {
       borderColor: ['#9BA4B5'],
       maxBarThickness: 35,
       borderRadius: 3,
+      borderWidth: 1,
+      label: '요금',
       data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+    },
+    {
+      type: 'pie',
+      yAxisID: 'y-left',
+      backgroundColor: ['#D8D8D8'],
+      borderColor: ['#D8D8D8'],
+      label: '예측값',
     },
   ],
 };
@@ -345,7 +355,45 @@ const optionsWater: any = {
       display: false,
     },
     legend: {
-      display: false,
+      display: true,
+      onClick: (click: any, legendItem: any, legend: any) => {
+        const datasets = legend.legendItems.map(
+          (dataset: any, index: number) => {
+            return dataset.text;
+          }
+        );
+
+        const index = datasets.indexOf(legendItem.text);
+        if (legend.chart.isDatasetVisible(index) === true)
+          legend.chart.hide(index);
+        else legend.chart.show(index);
+      },
+      labels: {
+        usePointStyle: true,
+        generateLabels: function (chart: any) {
+          let visibility: any = [];
+          for (let i = 0; i < chart.data.datasets.length; i++) {
+            if (chart.isDatasetVisible(i) === true) visibility.push(false);
+            else visibility.push(true);
+          }
+
+          let pointStyle: any = [];
+          chart.data.datasets.forEach((dataset: any) => {
+            if (dataset.type === 'line') pointStyle.push('line');
+            else pointStyle.push('rect');
+          });
+
+          return chart.data.datasets.map((dataset: any, idx: number) => ({
+            text: dataset.label,
+            fillStyle: dataset.backgroundColor
+              ? dataset?.backgroundColor[0]
+              : null,
+            strokeStyle: dataset.borderColor,
+            pointStyle: pointStyle[idx],
+            hidden: visibility[idx],
+          }));
+        },
+      },
     },
     tooltip: {
       callbacks: {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -62,9 +62,40 @@ const monthlyInitData: any = {
   datasets: [
     {
       backgroundColor: ['#6E85B7'],
+      borderColor: ['#6E85B7'],
       maxBarThickness: 35,
       borderRadius: 3,
       data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      label: '사용량',
+    },
+
+    {
+      type: 'pie',
+      backgroundColor: ['#D8D8D8'],
+      borderColor: ['#D8D8D8'],
+      label: '예측값',
+    },
+    {
+      backgroundColor: ['#ff6666'],
+      borderColor: ['#ff6666'],
+      type: 'pie',
+      maxBarThickness: 35,
+      borderRadius: 3,
+      label: '실사용 > 예측',
+    },
+  ],
+};
+
+const monthlyInitDataCarbonAll: any = {
+  labels: monthCategory,
+  datasets: [
+    {
+      backgroundColor: ['#6E85B7'],
+      borderColor: ['#6E85B7'],
+      maxBarThickness: 35,
+      borderRadius: 3,
+      data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      label: '사용량',
     },
   ],
 };
@@ -533,6 +564,79 @@ const options: any = {
     datalabels: {
       display: false,
     },
+
+    legend: {
+      display: true,
+      onClick: (click: any, legendItem: any, legend: any) => {
+        const datasets = legend.legendItems.map(
+          (dataset: any, index: number) => {
+            return dataset.text;
+          }
+        );
+
+        const index = datasets.indexOf(legendItem.text);
+        if (legend.chart.isDatasetVisible(index) === true)
+          legend.chart.hide(index);
+        else legend.chart.show(index);
+      },
+      labels: {
+        usePointStyle: true,
+        generateLabels: function (chart: any) {
+          let visibility: any = [];
+          for (let i = 0; i < chart.data.datasets.length; i++) {
+            if (chart.isDatasetVisible(i) === true) visibility.push(false);
+            else visibility.push(true);
+          }
+
+          let pointStyle: any = [];
+          chart.data.datasets.forEach((dataset: any) => {
+            if (dataset.type === 'line') pointStyle.push('line');
+            else pointStyle.push('rect');
+          });
+
+          return chart.data.datasets.map((dataset: any, idx: number) => ({
+            text: dataset.label,
+            fillStyle: dataset.backgroundColor
+              ? dataset?.backgroundColor[0]
+              : null,
+            strokeStyle: dataset.borderColor,
+            pointStyle: pointStyle[idx],
+            hidden: visibility[idx],
+          }));
+        },
+      },
+    },
+
+    tooltip: {
+      callbacks: {
+        title: (context: any) => context[0].label + '월',
+        label: (context: any) => {
+          let label = context.dataset.label + '' || '';
+          return context.parsed.y !== null ? context.parsed.y + 'Mwh' : null;
+        },
+      },
+    },
+  },
+  scales: {
+    x: {
+      grid: {
+        display: false,
+      },
+    },
+    y: {
+      grid: {
+        display: false,
+      },
+    },
+  },
+};
+
+const optionsBuildingElectricitiy: any = {
+  reponsive: false,
+  plugins: {
+    datalabels: {
+      display: false,
+    },
     legend: {
       display: false,
     },
@@ -541,7 +645,44 @@ const options: any = {
         title: (context: any) => context[0].label + '월',
         label: (context: any) => {
           let label = context.dataset.label + '' || '';
-          return context.parsed.y !== null ? context.parsed.y + 'Mwh' : null;
+          return context.parsed.y !== null
+            ? context.parsed.y.toLocaleString('ko-KR') + 'Mwh'
+            : null;
+        },
+      },
+    },
+  },
+  scales: {
+    x: {
+      grid: {
+        display: false,
+      },
+    },
+    y: {
+      grid: {
+        display: false,
+      },
+    },
+  },
+};
+
+const optionsBuildingGas: any = {
+  reponsive: false,
+  plugins: {
+    datalabels: {
+      display: false,
+    },
+    legend: {
+      display: false,
+    },
+    tooltip: {
+      callbacks: {
+        title: (context: any) => context[0].label + '월',
+        label: (context: any) => {
+          let label = context.dataset.label + '' || '';
+          return context.parsed.y !== null
+            ? context.parsed.y.toLocaleString('ko-KR') + 'm3'
+            : null;
         },
       },
     },
@@ -603,10 +744,6 @@ const optionsDoughnut: any = {
   },
   cutout: '65%',
   plugins: {
-    title: {
-      display: false,
-      text: '월별 에너지 사용량 비율',
-    },
     tooltips: {
       callbacks: {
         title: (context: any) => context[0].label + '월',
@@ -787,8 +924,47 @@ const optionsGas: any = {
       display: false,
     },
     legend: {
-      display: false,
+      display: true,
+      onClick: (click: any, legendItem: any, legend: any) => {
+        const datasets = legend.legendItems.map(
+          (dataset: any, index: number) => {
+            return dataset.text;
+          }
+        );
+
+        const index = datasets.indexOf(legendItem.text);
+        if (legend.chart.isDatasetVisible(index) === true)
+          legend.chart.hide(index);
+        else legend.chart.show(index);
+      },
+      labels: {
+        usePointStyle: true,
+        generateLabels: function (chart: any) {
+          let visibility: any = [];
+          for (let i = 0; i < chart.data.datasets.length; i++) {
+            if (chart.isDatasetVisible(i) === true) visibility.push(false);
+            else visibility.push(true);
+          }
+
+          let pointStyle: any = [];
+          chart.data.datasets.forEach((dataset: any) => {
+            if (dataset.type === 'line') pointStyle.push('line');
+            else pointStyle.push('rect');
+          });
+
+          return chart.data.datasets.map((dataset: any, idx: number) => ({
+            text: dataset.label,
+            fillStyle: dataset.backgroundColor
+              ? dataset?.backgroundColor[0]
+              : null,
+            strokeStyle: dataset.borderColor,
+            pointStyle: pointStyle[idx],
+            hidden: visibility[idx],
+          }));
+        },
+      },
     },
+
     tooltip: {
       callbacks: {
         title: (context: any) => context[0].label + '월',
@@ -1111,4 +1287,7 @@ export {
   optionsElectricityAll,
   optionsGasAll,
   monthlyInitAllData,
+  optionsBuildingElectricitiy,
+  monthlyInitDataCarbonAll,
+  optionsBuildingGas,
 };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -95,14 +95,6 @@ const monthlyInitAllData: any = {
   labels: monthCategory,
   datasets: [
     {
-      backgroundColor: ['#6E85B7'],
-      yAxisID: 'y-left',
-      maxBarThickness: 35,
-      borderRadius: 3,
-      data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
-      label: '사용량',
-    },
-    {
       type: 'line',
       yAxisID: 'y-right',
       backgroundColor: ['#FFFFFF'],
@@ -113,6 +105,15 @@ const monthlyInitAllData: any = {
       data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
       label: '요금',
     },
+    {
+      backgroundColor: ['#6E85B7'],
+      yAxisID: 'y-left',
+      maxBarThickness: 35,
+      borderRadius: 3,
+      data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+      label: '사용량',
+    },
+
     {
       type: 'pie',
       yAxisID: 'y-left',
@@ -373,7 +374,6 @@ const optionsElectricityAll: any = {
 
           let pointStyle: any = [];
           chart.data.datasets.forEach((dataset: any) => {
-            console.log(dataset.backgroundColor);
             if (dataset.type === 'line') pointStyle.push('line');
             else pointStyle.push('rect');
           });
@@ -395,7 +395,7 @@ const optionsElectricityAll: any = {
         title: (context: any) => context[0].label + '월',
         label: (context: any) => {
           let targetLabel = '';
-          if (context.datasetIndex === 0)
+          if (context.datasetIndex === 1)
             targetLabel = context.parsed.y.toLocaleString('ko-KR') + 'Mwh';
           else targetLabel = context.parsed.y.toLocaleString('ko-KR') + '만원';
           let label = context.dataset.label + '' || '';
@@ -435,14 +435,52 @@ const optionsGasAll: any = {
       display: false,
     },
     legend: {
-      display: false,
+      display: true,
+      onClick: (click: any, legendItem: any, legend: any) => {
+        const datasets = legend.legendItems.map(
+          (dataset: any, index: number) => {
+            return dataset.text;
+          }
+        );
+
+        const index = datasets.indexOf(legendItem.text);
+        if (legend.chart.isDatasetVisible(index) === true)
+          legend.chart.hide(index);
+        else legend.chart.show(index);
+      },
+      labels: {
+        usePointStyle: true,
+        generateLabels: function (chart: any) {
+          let visibility: any = [];
+          for (let i = 0; i < chart.data.datasets.length; i++) {
+            if (chart.isDatasetVisible(i) === true) visibility.push(false);
+            else visibility.push(true);
+          }
+
+          let pointStyle: any = [];
+          chart.data.datasets.forEach((dataset: any) => {
+            if (dataset.type === 'line') pointStyle.push('line');
+            else pointStyle.push('rect');
+          });
+
+          return chart.data.datasets.map((dataset: any, idx: number) => ({
+            text: dataset.label,
+            fillStyle: dataset.backgroundColor
+              ? dataset?.backgroundColor[0]
+              : null,
+            strokeStyle: dataset.borderColor,
+            pointStyle: pointStyle[idx],
+            hidden: visibility[idx],
+          }));
+        },
+      },
     },
     tooltip: {
       callbacks: {
         title: (context: any) => context[0].label + '월',
         label: (context: any) => {
           let targetLabel = '';
-          if (context.datasetIndex === 0)
+          if (context.datasetIndex === 1)
             targetLabel = context.parsed.y.toLocaleString('ko-KR') + 'm3';
           else targetLabel = context.parsed.y.toLocaleString('ko-KR') + '만원';
           let label = context.dataset.label + '' || '';
@@ -460,7 +498,7 @@ const optionsGasAll: any = {
     'y-left': {
       type: 'linear',
       position: 'left',
-      grace: '200%',
+      grace: '100%',
       grid: {
         display: false,
       },
@@ -468,6 +506,7 @@ const optionsGasAll: any = {
     'y-right': {
       type: 'linear',
       position: 'right',
+      grace: '50',
       grid: {
         display: false,
       },

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -734,6 +734,39 @@ const optionsSeason: any = {
   },
 };
 
+const optionsSeasonGas: any = {
+  reponsive: false,
+  plugins: {
+    datalabels: {
+      display: false,
+    },
+    legend: {
+      display: false,
+    },
+    tooltip: {
+      callbacks: {
+        title: (context: any) => context[0].label,
+        label: (context: any) => {
+          let label = context.dataset.label + '' || '';
+          return context.parsed.y !== null ? context.parsed.y + 'm3' : null;
+        },
+      },
+    },
+  },
+  scales: {
+    x: {
+      grid: {
+        display: false,
+      },
+    },
+    y: {
+      grid: {
+        display: false,
+      },
+    },
+  },
+};
+
 const optionsDoughnut: any = {
   layout: {
     padding: {
@@ -1290,4 +1323,5 @@ export {
   optionsBuildingElectricitiy,
   monthlyInitDataCarbonAll,
   optionsBuildingGas,
+  optionsSeasonGas,
 };

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -109,8 +109,16 @@ const monthlyInitAllData: any = {
       borderColor: ['#9BA4B5'],
       maxBarThickness: 35,
       borderRadius: 3,
+      borderWidth: 1,
       data: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
       label: '요금',
+    },
+    {
+      type: 'pie',
+      yAxisID: 'y-left',
+      backgroundColor: ['#D8D8D8'],
+      borderColor: ['#D8D8D8'],
+      label: '예측값',
     },
   ],
 };
@@ -342,6 +350,45 @@ const optionsElectricityAll: any = {
     },
     legend: {
       display: true,
+      onClick: (click: any, legendItem: any, legend: any) => {
+        const datasets = legend.legendItems.map(
+          (dataset: any, index: number) => {
+            return dataset.text;
+          }
+        );
+
+        const index = datasets.indexOf(legendItem.text);
+        if (legend.chart.isDatasetVisible(index) === true)
+          legend.chart.hide(index);
+        else legend.chart.show(index);
+      },
+      labels: {
+        usePointStyle: true,
+        generateLabels: function (chart: any) {
+          let visibility: any = [];
+          for (let i = 0; i < chart.data.datasets.length; i++) {
+            if (chart.isDatasetVisible(i) === true) visibility.push(false);
+            else visibility.push(true);
+          }
+
+          let pointStyle: any = [];
+          chart.data.datasets.forEach((dataset: any) => {
+            console.log(dataset.backgroundColor);
+            if (dataset.type === 'line') pointStyle.push('line');
+            else pointStyle.push('rect');
+          });
+
+          return chart.data.datasets.map((dataset: any, idx: number) => ({
+            text: dataset.label,
+            fillStyle: dataset.backgroundColor
+              ? dataset?.backgroundColor[0]
+              : null,
+            strokeStyle: dataset.borderColor,
+            pointStyle: pointStyle[idx],
+            hidden: visibility[idx],
+          }));
+        },
+      },
     },
     tooltip: {
       callbacks: {

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -140,6 +140,19 @@ const seasonInitData: any = {
   datasets: [
     {
       maxBarThickness: 35,
+      backgroundColor: ['#6E85B7'],
+      borderColor: ['#6E85B7'],
+      borderRadius: 3,
+      data: [],
+    },
+  ],
+};
+
+const seasonInitDataDoughnut: any = {
+  labels: ['봄', '여름', '가을', '겨울'],
+  datasets: [
+    {
+      maxBarThickness: 35,
       backgroundColor: [
         'rgba(98, 182, 203,0.7)',
         'rgba(190, 233, 232,0.7)',
@@ -1070,6 +1083,7 @@ export {
   yearCategory,
   indicateCategory,
   seasonInitData,
+  seasonInitDataDoughnut,
   gasChartCategory,
   buildingSrc,
   seasonIdx,


### PR DESCRIPTION
# 작업 분류
- [ ]  버그 수정
- [x] 신규 기능
- [ ] 리펙토링
- [ ] 기타
# 작업 개요
1. 전체 전기 예측 값 표기
2. 전체 가스 예측 값 표기
3. 전체 수도 예측 값 표기


# 상세 작업 내용
### 1. 전체 전기의 예측 값 표기
![전체전기-예측1](https://github.com/2023-1-Capstone/frontend/assets/76390004/831c4e72-15f4-4221-b9b9-df58594680f5)
- 전체 전기의 예측 값을 회색 막대와, 회색 점으로 표기하는 기능을 추가하였습니다.
- 실제 사용량이 예측 값보다 큰 경우 빨간색으로 표기하는 기능을 추가하였습니다.
- 범례를 추가하였습니다. 


### 2. 전체 가스의 예측 값 표기
![전체가스-예측1](https://github.com/2023-1-Capstone/frontend/assets/76390004/a95a0e24-61a5-4215-a6b5-5d3e92896f0b)
- 전체 가스의 예측 값을 회색 막대와, 회색 점으로 표기하는 기능을 추가하였습니다.
- 실제 사용량이 예측 값보다 큰 경우 빨간색으로 표기하는 기능을 추가하였습니다.
- 범례를 추가하였습니다. 

### 3. 전체 수도의 예측 값 표기
![수도](https://github.com/2023-1-Capstone/frontend/assets/76390004/5dcd9423-52e9-4232-bd4d-778ec1765ee1)
- 전체 수도의 예측 값을 회색 막대와, 회색 점으로 표기하는 기능을 추가하였습니다.
- 범례를 추가하였습니다. 
